### PR TITLE
Add utility to send and receive frames over the network

### DIFF
--- a/cassandraprotocol/client/auth.go
+++ b/cassandraprotocol/client/auth.go
@@ -1,0 +1,54 @@
+package client
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+)
+
+type Authenticator interface {
+	InitialResponse(name string) ([]byte, error)
+	EvaluateChallenge(challenge []byte) ([]byte, error)
+	GetInitialServerChallenge() []byte
+	GetMechanism() []byte
+}
+
+type PlainTextAuthenticator struct {
+	username string
+	password string
+}
+
+var (
+	initialServerChallenge = []byte("PLAIN-START")
+	mechanism              = []byte("PLAIN")
+)
+
+func (a *PlainTextAuthenticator) InitialResponse(authenticator string) ([]byte, error) {
+	switch authenticator {
+	case "com.datastax.bdp.cassandra.auth.DseAuthenticator":
+		return a.GetMechanism(), nil
+	case "org.apache.cassandra.auth.PasswordAuthenticator":
+		return a.EvaluateChallenge(a.GetInitialServerChallenge())
+	}
+	return nil, fmt.Errorf("unknown authenticator: %v", authenticator)
+}
+
+func (a *PlainTextAuthenticator) EvaluateChallenge(challenge []byte) ([]byte, error) {
+	if challenge == nil || bytes.Compare(challenge, initialServerChallenge) != 0 {
+		return nil, errors.New("incorrect SASL challenge from server")
+	}
+	buffer := make([]byte, len(a.username)+len(a.password)+2)
+	buffer[0] = 0
+	buffer = append(buffer[0:1], []byte(a.username)...)
+	buffer = append(buffer, 0)
+	buffer = append(buffer, []byte(a.password)...)
+	return buffer, nil
+}
+
+func (a *PlainTextAuthenticator) GetInitialServerChallenge() []byte {
+	return initialServerChallenge
+}
+
+func (a *PlainTextAuthenticator) GetMechanism() []byte {
+	return mechanism
+}

--- a/cassandraprotocol/client/client.go
+++ b/cassandraprotocol/client/client.go
@@ -1,0 +1,29 @@
+package client
+
+import (
+	"github.com/datastax/go-cassandra-native-protocol/cassandraprotocol/frame"
+	"net"
+)
+
+type CqlClient struct {
+	address string
+	codec   *frame.Codec
+}
+
+func NewCqlClient(address string, codec *frame.Codec) *CqlClient {
+	return &CqlClient{
+		address: address,
+		codec:   codec,
+	}
+}
+
+func (client *CqlClient) Connect() (*CqlConnection, error) {
+	c, err := net.Dial("tcp", client.address)
+	if err != nil {
+		return nil, err
+	}
+	return &CqlConnection{
+		conn:  c,
+		codec: client.codec,
+	}, nil
+}

--- a/cassandraprotocol/client/client_test.go
+++ b/cassandraprotocol/client/client_test.go
@@ -1,0 +1,247 @@
+package client
+
+import (
+	"fmt"
+	"github.com/datastax/go-cassandra-native-protocol/cassandraprotocol"
+	"github.com/datastax/go-cassandra-native-protocol/cassandraprotocol/compression"
+	"github.com/datastax/go-cassandra-native-protocol/cassandraprotocol/frame"
+	"github.com/datastax/go-cassandra-native-protocol/cassandraprotocol/message"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+var compressors = map[string]*frame.Codec{
+	"LZ4":    frame.NewCodec(frame.WithCompressor(&compression.Lz4Compressor{})),
+	"SNAPPY": frame.NewCodec(frame.WithCompressor(&compression.SnappyCompressor{})),
+	"NONE":   frame.NewCodec(),
+}
+
+// This test requires a remote server listening on localhost:9042 without authentication.
+func TestRemoteServerNoAuth(t *testing.T) {
+
+	for version := cassandraprotocol.ProtocolVersionMin; version <= cassandraprotocol.ProtocolVersionMax; version++ {
+		t.Run(fmt.Sprintf("version %v", version), func(t *testing.T) {
+
+			for compressor, frameCodec := range compressors {
+				t.Run(fmt.Sprintf("compression %v", compressor), func(t *testing.T) {
+
+					client := NewCqlClient("127.0.0.1:9042", frameCodec)
+					clientConn, err := client.Connect()
+					if err != nil {
+						return // skip test, no remote server available
+					}
+					defer func() { _ = clientConn.Close() }()
+
+					err = Handshake(clientConn, version, 1)
+					assert.Nil(t, err)
+
+					request, _ := frame.NewRequestFrame(version, 1, false, nil, &message.Query{
+						Query:   "SELECT * FROM system.local",
+						Options: message.NewQueryOptions(),
+					})
+					err = clientConn.Send(request)
+					assert.Nil(t, err)
+					fmt.Printf("CLIENT sent:     %v\n", request)
+
+					response, err := clientConn.Receive()
+					assert.Nil(t, err)
+					assert.NotNil(t, response)
+					assert.IsType(t, &message.RowsResult{}, response.Body.Message)
+					fmt.Printf("CLIENT received: %v\n", response)
+				})
+			}
+		})
+	}
+}
+
+// This test requires a remote server listening on localhost:9042 with authentication.
+func TestRemoteServerAuth(t *testing.T) {
+
+	for version := cassandraprotocol.ProtocolVersionMin; version <= cassandraprotocol.ProtocolVersionMax; version++ {
+		t.Run(fmt.Sprintf("version %v", version), func(t *testing.T) {
+
+			for compressor, frameCodec := range compressors {
+				t.Run(fmt.Sprintf("compression %v", compressor), func(t *testing.T) {
+
+					client := NewCqlClient("127.0.0.1:9042", frameCodec)
+					clientConn, err := client.Connect()
+					if err != nil {
+						return // skip test, no remote server available
+					}
+					defer func() { _ = clientConn.Close() }()
+
+					err = HandshakeAuth(clientConn, version, 1, "cassandra", "cassandra")
+					assert.Nil(t, err)
+
+					query, _ := frame.NewRequestFrame(version, 1, false, nil, &message.Query{
+						Query:   "SELECT * FROM system.local",
+						Options: message.NewQueryOptions(),
+					})
+					err = clientConn.Send(query)
+					assert.Nil(t, err)
+					fmt.Printf("CLIENT sent:     %v\n", query)
+
+					rows, err := clientConn.Receive()
+					assert.Nil(t, err)
+					assert.NotNil(t, rows)
+					assert.IsType(t, &message.RowsResult{}, rows.Body.Message)
+					fmt.Printf("CLIENT received: %v\n", rows)
+				})
+			}
+		})
+	}
+}
+
+func TestLocalServer(t *testing.T) {
+
+	for version := cassandraprotocol.ProtocolVersionMin; version <= cassandraprotocol.ProtocolVersionMax; version++ {
+		t.Run(fmt.Sprintf("version %v", version), func(t *testing.T) {
+
+			for compressor, frameCodec := range compressors {
+				t.Run(fmt.Sprintf("compression %v", compressor), func(t *testing.T) {
+
+					server := NewCqlServer("127.0.0.1:9043", frameCodec)
+					defer func() { _ = server.Close() }()
+
+					client := NewCqlClient("127.0.0.1:9043", frameCodec)
+
+					clientConn, serverConn, err := server.Bind(client)
+					assert.Nil(t, err)
+
+					defer func() { _ = clientConn.Close(); _ = serverConn.Close() }()
+
+					msg := StartupRequest(clientConn, version, 1)
+					_ = clientConn.Send(msg)
+					fmt.Printf("CLIENT sent:     %v\n", msg)
+
+					msg, _ = serverConn.Receive()
+					assert.NotNil(t, msg)
+					assert.IsType(t, &message.Startup{}, msg.Body.Message)
+					fmt.Printf("SERVER received: %v\n", msg)
+
+					msg, _ = frame.NewResponseFrame(version, 1, nil, nil, nil, &message.Ready{})
+					_ = serverConn.Send(msg)
+					fmt.Printf("SERVER sent:     %v\n", msg)
+
+					msg, _ = clientConn.Receive()
+					assert.NotNil(t, msg)
+					assert.IsType(t, &message.Ready{}, msg.Body.Message)
+					fmt.Printf("CLIENT received: %v\n", msg)
+
+					msg, _ = frame.NewRequestFrame(version, 1, false, nil, &message.Query{
+						Query:   "SELECT * FROM system.local",
+						Options: message.NewQueryOptions(),
+					})
+					err = clientConn.Send(msg)
+					fmt.Printf("CLIENT sent:     %v\n", msg)
+
+					msg, _ = serverConn.Receive()
+					assert.NotNil(t, msg)
+					assert.IsType(t, &message.Query{}, msg.Body.Message)
+					fmt.Printf("SERVER received: %v\n", msg)
+
+					msg, _ = frame.NewResponseFrame(
+						version,
+						1,
+						nil,
+						nil,
+						nil,
+						message.NewRowsResult(message.WithRowsMetadata(
+							message.NewRowsMetadata(message.NoColumnMetadata(1))),
+							message.WithRowsData(
+								[][]byte{
+									{0, 0, 0, 4, 1, 2, 3, 4},
+								},
+								[][]byte{
+									{0, 0, 0, 4, 5, 6, 7, 8},
+								},
+							),
+						),
+					)
+					_ = serverConn.Send(msg)
+					fmt.Printf("SERVER sent:     %v\n", msg)
+
+					msg, _ = clientConn.Receive()
+					assert.NotNil(t, msg)
+					assert.IsType(t, &message.RowsResult{}, msg.Body.Message)
+					fmt.Printf("CLIENT received: %v\n", msg)
+				})
+			}
+		})
+	}
+}
+
+func TestLocalServerDiscardBody(t *testing.T) {
+
+	for version := cassandraprotocol.ProtocolVersionMin; version <= cassandraprotocol.ProtocolVersionMax; version++ {
+		t.Run(fmt.Sprintf("version %v", version), func(t *testing.T) {
+
+			for compressor, frameCodec := range compressors {
+				t.Run(fmt.Sprintf("compression %v", compressor), func(t *testing.T) {
+
+					server := NewCqlServer("127.0.0.1:9043", frameCodec)
+					defer func() { _ = server.Close() }()
+
+					client := NewCqlClient("127.0.0.1:9043", frameCodec)
+
+					clientConn, serverConn, err := server.Bind(client)
+					assert.Nil(t, err)
+
+					defer func() { _ = clientConn.Close(); _ = serverConn.Close() }()
+
+					msg := StartupRequest(clientConn, version, 1)
+					_ = clientConn.Send(msg)
+					fmt.Printf("CLIENT sent:     %v\n", msg)
+
+					header, _ := serverConn.ReceiveHeader()
+					assert.NotNil(t, header)
+					fmt.Printf("SERVER received: %v\n", header)
+
+					msg, _ = frame.NewResponseFrame(version, 1, nil, nil, nil, &message.Ready{})
+					_ = serverConn.Send(msg)
+					fmt.Printf("SERVER sent:     %v\n", msg)
+
+					header, _ = clientConn.ReceiveHeader()
+					assert.NotNil(t, header)
+					fmt.Printf("CLIENT received: %v\n", header)
+
+					msg, _ = frame.NewRequestFrame(version, 1, false, nil, &message.Query{
+						Query:   "SELECT * FROM system.local",
+						Options: message.NewQueryOptions(),
+					})
+					err = clientConn.Send(msg)
+					fmt.Printf("CLIENT sent:     %v\n", msg)
+
+					header, _ = serverConn.ReceiveHeader()
+					assert.NotNil(t, header)
+					fmt.Printf("SERVER received: %v\n", header)
+
+					msg, _ = frame.NewResponseFrame(
+						version,
+						1,
+						nil,
+						nil,
+						nil,
+						message.NewRowsResult(message.WithRowsMetadata(
+							message.NewRowsMetadata(message.NoColumnMetadata(1))),
+							message.WithRowsData(
+								[][]byte{
+									{0, 0, 0, 4, 1, 2, 3, 4},
+								},
+								[][]byte{
+									{0, 0, 0, 4, 5, 6, 7, 8},
+								},
+							),
+						),
+					)
+					_ = serverConn.Send(msg)
+					fmt.Printf("SERVER sent:     %v\n", msg)
+
+					header, _ = clientConn.ReceiveHeader()
+					assert.NotNil(t, header)
+					fmt.Printf("CLIENT received: %v\n", header)
+				})
+			}
+		})
+	}
+}

--- a/cassandraprotocol/client/client_test.go
+++ b/cassandraprotocol/client/client_test.go
@@ -110,7 +110,7 @@ func TestLocalServer(t *testing.T) {
 
 					defer func() { _ = clientConn.Close(); _ = serverConn.Close() }()
 
-					msg := StartupRequest(clientConn, version, 1)
+					msg := NewStartupRequest(clientConn, version, 1)
 					_ = clientConn.Send(msg)
 					fmt.Printf("CLIENT sent:     %v\n", msg)
 
@@ -189,7 +189,7 @@ func TestLocalServerDiscardBody(t *testing.T) {
 
 					defer func() { _ = clientConn.Close(); _ = serverConn.Close() }()
 
-					msg := StartupRequest(clientConn, version, 1)
+					msg := NewStartupRequest(clientConn, version, 1)
 					_ = clientConn.Send(msg)
 					fmt.Printf("CLIENT sent:     %v\n", msg)
 

--- a/cassandraprotocol/client/client_test.go
+++ b/cassandraprotocol/client/client_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"flag"
 	"fmt"
 	"github.com/datastax/go-cassandra-native-protocol/cassandraprotocol"
 	"github.com/datastax/go-cassandra-native-protocol/cassandraprotocol/compression"
@@ -16,9 +17,17 @@ var compressors = map[string]*frame.Codec{
 	"NONE":   frame.NewCodec(),
 }
 
+var ccmAvailable bool
+
+func init() {
+	flag.BoolVar(&ccmAvailable, "ccm", false, "whether a CCM cluster is available on localhost:9042")
+}
+
 // This test requires a remote server listening on localhost:9042 without authentication.
 func TestRemoteServerNoAuth(t *testing.T) {
-
+	if !ccmAvailable {
+		t.Skip("No CCM cluster available")
+	}
 	for version := cassandraprotocol.ProtocolVersionMin; version <= cassandraprotocol.ProtocolVersionMax; version++ {
 		t.Run(fmt.Sprintf("version %v", version), func(t *testing.T) {
 
@@ -56,6 +65,9 @@ func TestRemoteServerNoAuth(t *testing.T) {
 
 // This test requires a remote server listening on localhost:9042 with authentication.
 func TestRemoteServerAuth(t *testing.T) {
+	if !ccmAvailable {
+		t.Skip("No CCM cluster available")
+	}
 
 	for version := cassandraprotocol.ProtocolVersionMin; version <= cassandraprotocol.ProtocolVersionMax; version++ {
 		t.Run(fmt.Sprintf("version %v", version), func(t *testing.T) {

--- a/cassandraprotocol/client/client_test.go
+++ b/cassandraprotocol/client/client_test.go
@@ -68,7 +68,6 @@ func TestRemoteServerAuth(t *testing.T) {
 	if !ccmAvailable {
 		t.Skip("No CCM cluster available")
 	}
-
 	for version := cassandraprotocol.ProtocolVersionMin; version <= cassandraprotocol.ProtocolVersionMax; version++ {
 		t.Run(fmt.Sprintf("version %v", version), func(t *testing.T) {
 

--- a/cassandraprotocol/client/connection.go
+++ b/cassandraprotocol/client/connection.go
@@ -1,0 +1,35 @@
+package client
+
+import (
+	"github.com/datastax/go-cassandra-native-protocol/cassandraprotocol/frame"
+	"net"
+)
+
+type CqlConnection struct {
+	conn  net.Conn
+	codec *frame.Codec
+}
+
+func (c *CqlConnection) Send(f *frame.Frame) error {
+	return c.codec.Encode(f, c.conn)
+}
+
+func (c *CqlConnection) Receive() (*frame.Frame, error) {
+	return c.codec.Decode(c.conn)
+}
+
+func (c *CqlConnection) ReceiveHeader() (header *frame.RawHeader, err error) {
+	if header, err = c.codec.DecodeHeader(c.conn); err != nil {
+		return nil, err
+	} else if err = c.codec.DiscardBody(header.BodyLength, c.conn); err != nil {
+		return nil, err
+	}
+	return header, nil
+}
+
+func (c *CqlConnection) Close() error {
+	if c.conn != nil {
+		return c.conn.Close()
+	}
+	return nil
+}

--- a/cassandraprotocol/client/handshake.go
+++ b/cassandraprotocol/client/handshake.go
@@ -1,0 +1,69 @@
+package client
+
+import (
+	"fmt"
+	"github.com/datastax/go-cassandra-native-protocol/cassandraprotocol"
+	"github.com/datastax/go-cassandra-native-protocol/cassandraprotocol/frame"
+	"github.com/datastax/go-cassandra-native-protocol/cassandraprotocol/message"
+)
+
+func StartupRequest(c *CqlConnection, version cassandraprotocol.ProtocolVersion, streamId int16) *frame.Frame {
+	var startup *message.Startup
+	if c.codec.CompressionAlgorithm() == "NONE" {
+		startup = message.NewStartup()
+	} else {
+		startup = message.NewStartup(message.WithCompression(c.codec.CompressionAlgorithm()))
+	}
+	request, _ := frame.NewRequestFrame(version, streamId, false, nil, startup)
+	return request
+}
+
+func Handshake(client *CqlConnection, version cassandraprotocol.ProtocolVersion, streamId int16) error {
+	if err := client.Send(StartupRequest(client, version, streamId)); err != nil {
+		return err
+	} else if response, err := client.Receive(); err != nil {
+		return err
+	} else if _, ok := response.Body.Message.(*message.Ready); !ok {
+		return fmt.Errorf("expected READY, got %T", response.Body.Message)
+	} else {
+		return nil
+	}
+}
+
+func HandshakeAuth(client *CqlConnection, version cassandraprotocol.ProtocolVersion, streamId int16, username string, password string) error {
+	authenticator := &PlainTextAuthenticator{
+		username: username,
+		password: password,
+	}
+	if err := client.Send(StartupRequest(client, version, streamId)); err != nil {
+		return err
+	} else if response, err := client.Receive(); err != nil {
+		return err
+	} else if authenticate, ok := response.Body.Message.(*message.Authenticate); !ok {
+		return fmt.Errorf("expected AUTHENTICATE, got %v", response.Body.Message)
+	} else if initialResponse, err := authenticator.InitialResponse(authenticate.Authenticator); err != nil {
+		return err
+	} else if authResponse, err := frame.NewRequestFrame(version, streamId, false, nil, &message.AuthResponse{Token: initialResponse}); err != nil {
+		return err
+	} else if err := client.Send(authResponse); err != nil {
+		return err
+	} else if response, err := client.Receive(); err != nil {
+		return err
+	} else if _, isAuthSuccess := response.Body.Message.(*message.AuthSuccess); isAuthSuccess {
+		return nil
+	} else if authChallenge, isAuthChallenge := response.Body.Message.(*message.AuthChallenge); !isAuthChallenge {
+		return fmt.Errorf("expected AUTH_CHALLENGE or AUTH_SUCCESS, got %v", response.Body.Message)
+	} else if challenge, err := authenticator.EvaluateChallenge(authChallenge.Token); err != nil {
+		return err
+	} else if authResponse, err := frame.NewRequestFrame(version, streamId, false, nil, &message.AuthResponse{Token: challenge}); err != nil {
+		return err
+	} else if err := client.Send(authResponse); err != nil {
+		return err
+	} else if response, err := client.Receive(); err != nil {
+		return err
+	} else if _, isAuthSuccess := response.Body.Message.(*message.AuthSuccess); !isAuthSuccess {
+		return fmt.Errorf("expected AUTH_SUCCESS, got %v", response.Body.Message)
+	} else {
+		return nil
+	}
+}

--- a/cassandraprotocol/client/handshake.go
+++ b/cassandraprotocol/client/handshake.go
@@ -7,7 +7,7 @@ import (
 	"github.com/datastax/go-cassandra-native-protocol/cassandraprotocol/message"
 )
 
-func StartupRequest(c *CqlConnection, version cassandraprotocol.ProtocolVersion, streamId int16) *frame.Frame {
+func NewStartupRequest(c *CqlConnection, version cassandraprotocol.ProtocolVersion, streamId int16) *frame.Frame {
 	var startup *message.Startup
 	if c.codec.CompressionAlgorithm() == "NONE" {
 		startup = message.NewStartup()
@@ -19,7 +19,7 @@ func StartupRequest(c *CqlConnection, version cassandraprotocol.ProtocolVersion,
 }
 
 func Handshake(client *CqlConnection, version cassandraprotocol.ProtocolVersion, streamId int16) error {
-	if err := client.Send(StartupRequest(client, version, streamId)); err != nil {
+	if err := client.Send(NewStartupRequest(client, version, streamId)); err != nil {
 		return err
 	} else if response, err := client.Receive(); err != nil {
 		return err
@@ -35,7 +35,7 @@ func HandshakeAuth(client *CqlConnection, version cassandraprotocol.ProtocolVers
 		username: username,
 		password: password,
 	}
-	if err := client.Send(StartupRequest(client, version, streamId)); err != nil {
+	if err := client.Send(NewStartupRequest(client, version, streamId)); err != nil {
 		return err
 	} else if response, err := client.Receive(); err != nil {
 		return err

--- a/cassandraprotocol/client/server.go
+++ b/cassandraprotocol/client/server.go
@@ -1,0 +1,74 @@
+package client
+
+import (
+	"errors"
+	"github.com/datastax/go-cassandra-native-protocol/cassandraprotocol/frame"
+	"net"
+	"time"
+)
+
+type CqlServer struct {
+	address  string
+	codec    *frame.Codec
+	listener net.Listener
+}
+
+func NewCqlServer(address string, codec *frame.Codec) *CqlServer {
+	return &CqlServer{
+		address: address,
+		codec:   codec,
+	}
+}
+
+func (server *CqlServer) Listen() (err error) {
+	if server.listener == nil {
+		server.listener, err = net.Listen("tcp", server.address)
+	}
+	return err
+}
+
+func (server *CqlServer) Bind(client *CqlClient) (clientConn *CqlConnection, serverConn *CqlConnection, err error) {
+	if err = server.Listen(); err != nil {
+		return nil, nil, err
+	}
+	type result struct {
+		conn *CqlConnection
+		err  error
+	}
+	clientChan := make(chan *result)
+	serverChan := make(chan *result)
+	go func() {
+		conn, err := client.Connect()
+		clientChan <- &result{conn, err}
+	}()
+	go func() {
+		conn, err := server.listener.Accept()
+		serverChan <- &result{&CqlConnection{conn, server.codec}, err}
+	}()
+	select {
+	case result := <-clientChan:
+		if result.err != nil {
+			return nil, nil, err
+		}
+		clientConn = result.conn
+	case <-time.After(time.Minute):
+		return nil, nil, errors.New("timeout waiting for client")
+	}
+	select {
+	case result := <-serverChan:
+		if result.err != nil {
+			return nil, nil, err
+		}
+		serverConn = result.conn
+	case <-time.After(time.Minute):
+		return nil, nil, errors.New("timeout waiting for server")
+	}
+	return
+}
+
+func (server *CqlServer) Close() error {
+	if server.listener != nil {
+		return server.listener.Close()
+	}
+	return nil
+}

--- a/cassandraprotocol/compression/compressor.go
+++ b/cassandraprotocol/compression/compressor.go
@@ -5,6 +5,7 @@ import (
 )
 
 type MessageCompressor interface {
+	Algorithm() string
 	Compress(uncompressedMessage *bytes.Buffer) (compressedMessage *bytes.Buffer, err error)
 	Decompress(compressedMessage *bytes.Buffer) (decompressedMessage *bytes.Buffer, err error)
 }

--- a/cassandraprotocol/compression/lz4.go
+++ b/cassandraprotocol/compression/lz4.go
@@ -2,25 +2,67 @@ package compression
 
 import (
 	"bytes"
+	"encoding/binary"
+	"fmt"
 	"github.com/pierrec/lz4"
 )
 
+// Lz4Compressor satisfies MessageCompressor for the LZ4 algorithm.
+// Note: Cassandra expects lz4-compressed bodies to start with a 4-byte integer holding the decompressed message length.
+// The Go implementation of lz4 used here does not include that, so we need to do it manually when encoding and
+// decoding.
 type Lz4Compressor struct{}
 
+func (l Lz4Compressor) Algorithm() string {
+	return "LZ4"
+}
+
 func (l Lz4Compressor) Compress(uncompressedMessage *bytes.Buffer) (*bytes.Buffer, error) {
-	compressedMessage := make([]byte, lz4.CompressBlockBound(uncompressedMessage.Len()))
-	n, err := lz4.CompressBlock(uncompressedMessage.Bytes(), compressedMessage, nil)
-	if err != nil {
+	maxCompressedSize := lz4.CompressBlockBound(uncompressedMessage.Len())
+	// allocate enough space for the max compressed size + 4 bytes for the decompressed length
+	compressedMessage := make([]byte, maxCompressedSize+4)
+	// write the decompressed length in the 4 first bytes
+	binary.BigEndian.PutUint32(compressedMessage, uint32(uncompressedMessage.Len()))
+	// compress the message and write the result to the destination buffer starting at offset 4;
+	// note that for empty messages, this results in a single byte being written and written = 1;
+	// this is normal and is what Cassandra expects for empty compressed messages.
+	if written, err := lz4.CompressBlock(uncompressedMessage.Bytes(), compressedMessage[4:], nil); err != nil {
 		return nil, err
+	} else {
+		// cap the compressed buffer at n + 4 bytes
+		return bytes.NewBuffer(compressedMessage[:written+4]), nil
 	}
-	return bytes.NewBuffer(compressedMessage[:n]), nil
 }
 
 func (l Lz4Compressor) Decompress(compressedMessage *bytes.Buffer) (*bytes.Buffer, error) {
-	decompressedMessage := make([]byte, 10*compressedMessage.Len())
-	n, err := lz4.UncompressBlock(compressedMessage.Bytes(), decompressedMessage)
-	if err != nil {
+	// read the decompressed length first
+	var decompressedLength uint32
+	if err := binary.Read(compressedMessage, binary.BigEndian, &decompressedLength); err != nil {
 		return nil, err
+	} else {
+		// if decompressed length is zero, the remaining buffer will contain a single byte that should be discarded
+		if decompressedLength == 0 {
+			return &bytes.Buffer{}, nil
+		}
+		// decompress the message
+		var decompressedMessage []byte
+		var written int
+		compressedLength := compressedMessage.Len()
+		remaining := compressedMessage.Bytes()
+		// try destination buffers of increased length to avoid allocating too much space, starting with twice the
+		// compressed length and up to eight times the compressed length
+		for i := compressedLength * 2; i <= compressedLength*8; i *= 2 {
+			decompressedMessage = make([]byte, i)
+			if written, err = lz4.UncompressBlock(remaining, decompressedMessage); err == nil {
+				break
+			}
+		}
+		if err != nil {
+			return nil, err
+		} else if written != int(decompressedLength) {
+			return nil, fmt.Errorf("decompressed body length mismatch, expected %d, got: %d", decompressedLength, written)
+		} else {
+			return bytes.NewBuffer(decompressedMessage[:written]), nil
+		}
 	}
-	return bytes.NewBuffer(decompressedMessage[:n]), nil
 }

--- a/cassandraprotocol/compression/snappy.go
+++ b/cassandraprotocol/compression/snappy.go
@@ -7,6 +7,10 @@ import (
 
 type SnappyCompressor struct{}
 
+func (l SnappyCompressor) Algorithm() string {
+	return "SNAPPY"
+}
+
 func (l SnappyCompressor) Compress(uncompressedMessage *bytes.Buffer) (*bytes.Buffer, error) {
 	compressedMessage := snappy.Encode(nil, uncompressedMessage.Bytes())
 	return bytes.NewBuffer(compressedMessage), nil

--- a/cassandraprotocol/frame/codec.go
+++ b/cassandraprotocol/frame/codec.go
@@ -6,7 +6,7 @@ import (
 	"github.com/datastax/go-cassandra-native-protocol/cassandraprotocol/message"
 )
 
-type codec struct {
+type Codec struct {
 	compressor compression.MessageCompressor
 	codecs     map[cassandraprotocol.OpCode]message.Codec
 }
@@ -30,10 +30,10 @@ var defaultCodecs = []message.Codec{
 	&message.AuthSuccessCodec{},
 }
 
-type CodecCustomizer func(*codec)
+type CodecCustomizer func(*Codec)
 
-func NewCodec(customizers ...CodecCustomizer) *codec {
-	codec := &codec{codecs: makeCodecsMap(defaultCodecs)}
+func NewCodec(customizers ...CodecCustomizer) *Codec {
+	codec := &Codec{codecs: makeCodecsMap(defaultCodecs)}
 	for _, customizer := range customizers {
 		customizer(codec)
 	}
@@ -41,14 +41,22 @@ func NewCodec(customizers ...CodecCustomizer) *codec {
 }
 
 func WithCompressor(compressor compression.MessageCompressor) CodecCustomizer {
-	return func(codec *codec) {
+	return func(codec *Codec) {
 		codec.compressor = compressor
 	}
 }
 
 func WithMessageCodecs(codecs ...message.Codec) CodecCustomizer {
-	return func(codec *codec) {
+	return func(codec *Codec) {
 		codec.codecs = makeCodecsMap(codecs)
+	}
+}
+
+func (c *Codec) CompressionAlgorithm() string {
+	if c.compressor == nil {
+		return "NONE"
+	} else {
+		return c.compressor.Algorithm()
 	}
 }
 

--- a/cassandraprotocol/frame/codec_test.go
+++ b/cassandraprotocol/frame/codec_test.go
@@ -1,6 +1,7 @@
 package frame
 
 import (
+	"bytes"
 	"github.com/datastax/go-cassandra-native-protocol/cassandraprotocol"
 	"github.com/datastax/go-cassandra-native-protocol/cassandraprotocol/compression"
 	"github.com/datastax/go-cassandra-native-protocol/cassandraprotocol/message"
@@ -46,9 +47,10 @@ func TestFrameEncodeDecode(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if encodedFrame, err := codec.Encode(test.frame); err != nil {
+			encodedFrame := bytes.Buffer{}
+			if err := codec.Encode(test.frame, &encodedFrame); err != nil {
 				assert.Equal(t, test.err, err)
-			} else if decodedFrame, err := codec.Decode(encodedFrame); err != nil {
+			} else if decodedFrame, err := codec.Decode(&encodedFrame); err != nil {
 				assert.Equal(t, test.err, err)
 			} else {
 				assert.Equal(t, test.frame, decodedFrame)
@@ -58,7 +60,7 @@ func TestFrameEncodeDecode(t *testing.T) {
 }
 
 func TestFrameEncodeDecodeWithCompression(t *testing.T) {
-	codecs := map[string]*codec{
+	codecs := map[string]*Codec{
 		"lz4":    NewCodec(WithCompressor(compression.Lz4Compressor{})),
 		"snappy": NewCodec(WithCompressor(compression.SnappyCompressor{})),
 	}
@@ -74,9 +76,10 @@ func TestFrameEncodeDecodeWithCompression(t *testing.T) {
 		t.Run(algorithm, func(t *testing.T) {
 			for _, test := range tests {
 				t.Run(test.name, func(t *testing.T) {
-					if encodedFrame, err := codec.Encode(test.frame); err != nil {
+					encodedFrame := bytes.Buffer{}
+					if err := codec.Encode(test.frame, &encodedFrame); err != nil {
 						assert.Equal(t, test.err, err)
-					} else if decodedFrame, err := codec.Decode(encodedFrame); err != nil {
+					} else if decodedFrame, err := codec.Decode(&encodedFrame); err != nil {
 						assert.Equal(t, test.err, err)
 					} else {
 						assert.Equal(t, test.frame, decodedFrame)

--- a/cassandraprotocol/frame/decoder.go
+++ b/cassandraprotocol/frame/decoder.go
@@ -5,110 +5,134 @@ import (
 	"errors"
 	"fmt"
 	"github.com/datastax/go-cassandra-native-protocol/cassandraprotocol"
-	"github.com/datastax/go-cassandra-native-protocol/cassandraprotocol/message"
 	"github.com/datastax/go-cassandra-native-protocol/cassandraprotocol/primitives"
 	"io"
+	"io/ioutil"
 )
 
-func (c *codec) Decode(frame *bytes.Buffer) (*Frame, error) {
-	frameLength := frame.Len()
-	if isResponse, version, flags, streamId, opCode, declaredBodyLength, err := c.decodeHeader(frame); err != nil {
+// Decode decodes the entre frame, decompressing the body if needed.
+func (c *Codec) Decode(source io.Reader) (*Frame, error) {
+	if rawHeader, err := c.DecodeHeader(source); err != nil {
 		return nil, fmt.Errorf("cannot decode frame header: %w", err)
+	} else if body, err := c.DecodeBody(rawHeader, source); err != nil {
+		return nil, fmt.Errorf("cannot decode frame body: %w", err)
 	} else {
-		actualBodyLength := frameLength - encodedHeaderLength
-		if int(declaredBodyLength) != actualBodyLength {
-			return nil, errors.New(fmt.Sprintf(
-				"declared body length in header (%d) does not match actual body length (%d)",
-				declaredBodyLength,
-				actualBodyLength))
+		header := &Header{
+			Version:          rawHeader.Version,
+			StreamId:         int16(rawHeader.StreamId & 0xFFFF),
+			TracingRequested: body.TracingId != nil || rawHeader.Flags&cassandraprotocol.HeaderFlagTracing != 0,
 		}
-		if compressed := flags&cassandraprotocol.HeaderFlagCompressed > 0; compressed {
-			if frame, err = c.compressor.Decompress(frame); err != nil {
-				return nil, fmt.Errorf("cannot decompress frame body: %w", err)
-			}
-		}
-		if tracingId, customPayload, warnings, msg, err := c.decodeBody(isResponse, version, flags, opCode, frame); err != nil {
-			return nil, fmt.Errorf("cannot decode frame body: %w", err)
-		} else {
-			header := &Header{
-				Version:          version,
-				StreamId:         int16(streamId & 0xFFFF),
-				TracingRequested: tracingId != nil || flags&cassandraprotocol.HeaderFlagTracing != 0,
-			}
-			body := Body{
-				TracingId:     tracingId,
-				CustomPayload: customPayload,
-				Warnings:      warnings,
-				Message:       msg,
-			}
-			return &Frame{Header: header, Body: &body}, nil
-		}
+		return &Frame{Header: header, Body: body}, nil
 	}
 }
 
-func (c *codec) decodeHeader(source io.Reader) (
-	isResponse bool,
-	version cassandraprotocol.ProtocolVersion,
-	flags cassandraprotocol.HeaderFlag,
-	streamId uint16,
-	opCode cassandraprotocol.OpCode,
-	bodyLength int32,
-	err error,
-) {
+// A low-level representation of a frame header, as it is parsed from an encoded frame.
+type RawHeader struct {
+	IsResponse bool
+	Version    cassandraprotocol.ProtocolVersion
+	Flags      cassandraprotocol.HeaderFlag
+	StreamId   uint16
+	OpCode     cassandraprotocol.OpCode
+	BodyLength int32
+}
+
+func (r RawHeader) String() string {
+	return fmt.Sprintf("{response: %v, version: %v, flags: %08b, stream id: %v, opcode: %v, body length: %v}",
+		r.IsResponse, r.Version, r.Flags, r.StreamId, r.OpCode, r.BodyLength)
+}
+
+// DecodeHeader only decodes the frame header, leaving the body contents in the source. After calling this function,
+// one must either call DecodeBody or DiscardBody to fully read or discard the body contents.
+func (c *Codec) DecodeHeader(source io.Reader) (*RawHeader, error) {
 	if versionAndDirection, err := primitives.ReadByte(source); err != nil {
-		err = fmt.Errorf("cannot decode header version and direction: %w", err)
+		return nil, fmt.Errorf("cannot decode header version and direction: %w", err)
 	} else {
-		isResponse = (versionAndDirection & 0b1000_0000) > 0
-		version = versionAndDirection & 0b0111_1111
-		if flags, err = primitives.ReadByte(source); err != nil {
-			err = fmt.Errorf("cannot decode header flags: %w", err)
-		} else if version == cassandraprotocol.ProtocolVersionBeta && flags&cassandraprotocol.HeaderFlagUseBeta == 0 {
-			err = fmt.Errorf("expected USE_BETA flag to be set for protocol version %v", version)
-		} else if streamId, err = primitives.ReadShort(source); err != nil {
-			err = fmt.Errorf("cannot decode header stream id: %w", err)
-		} else if opCode, err = primitives.ReadByte(source); err != nil {
-			err = fmt.Errorf("cannot decode header opcode: %w", err)
-		} else if bodyLength, err = primitives.ReadInt(source); err != nil {
-			err = fmt.Errorf("cannot decode header body length: %w", err)
+		isResponse := (versionAndDirection & 0b1000_0000) > 0
+		version := versionAndDirection & 0b0111_1111
+		header := &RawHeader{
+			IsResponse: isResponse,
+			Version:    version,
 		}
+		if version < cassandraprotocol.ProtocolVersionMin || version > cassandraprotocol.ProtocolVersionMax {
+			return nil, fmt.Errorf("unsupported protocol version: %v", version)
+		} else if header.Flags, err = primitives.ReadByte(source); err != nil {
+			return nil, fmt.Errorf("cannot decode header flags: %w", err)
+		} else if version == cassandraprotocol.ProtocolVersionBeta && header.Flags&cassandraprotocol.HeaderFlagUseBeta == 0 {
+			return nil, fmt.Errorf("expected USE_BETA flag to be set for protocol version %v", version)
+		} else if header.StreamId, err = primitives.ReadShort(source); err != nil {
+			return nil, fmt.Errorf("cannot decode header stream id: %w", err)
+		} else if header.OpCode, err = primitives.ReadByte(source); err != nil {
+			return nil, fmt.Errorf("cannot decode header opcode: %w", err)
+		} else if header.BodyLength, err = primitives.ReadInt(source); err != nil {
+			return nil, fmt.Errorf("cannot decode header body length: %w", err)
+		}
+		return header, err
 	}
-	return isResponse, version, flags, streamId, opCode, bodyLength, err
 }
 
-func (c *codec) decodeBody(
-	isResponse bool,
-	version cassandraprotocol.ProtocolVersion,
-	flags cassandraprotocol.HeaderFlag,
-	opCode cassandraprotocol.OpCode,
-	source io.Reader,
-) (
-	tracingId *primitives.UUID,
-	customPayload map[string][]byte,
-	warnings []string,
-	message message.Message,
-	err error,
-) {
-	if isResponse && flags&cassandraprotocol.HeaderFlagTracing > 0 {
-		if tracingId, err = primitives.ReadUuid(source); err != nil {
-			err = fmt.Errorf("cannot decode body tracing id: %w", err)
+// DecodeBody decodes a frame body, decompressing it if required. It is illegal to call this method before calling
+// DecodeHeader.
+func (c *Codec) DecodeBody(header *RawHeader, source io.Reader) (body *Body, err error) {
+	if compressed := header.Flags&cassandraprotocol.HeaderFlagCompressed > 0; compressed {
+		if c.compressor == nil {
+			return nil, errors.New("cannot decompress body: no compressor available")
+		} else if source, err = c.DecompressBody(header.BodyLength, source); err != nil {
+			return nil, fmt.Errorf("cannot decompress body: %w", err)
 		}
 	}
-	if err == nil && flags&cassandraprotocol.HeaderFlagCustomPayload > 0 {
-		if customPayload, err = primitives.ReadBytesMap(source); err != nil {
-			err = fmt.Errorf("cannot decode body custom payload: %w", err)
+	body = &Body{}
+	if header.IsResponse && header.Flags&cassandraprotocol.HeaderFlagTracing > 0 {
+		if body.TracingId, err = primitives.ReadUuid(source); err != nil {
+			return nil, fmt.Errorf("cannot decode body tracing id: %w", err)
 		}
 	}
-	if err == nil && isResponse && flags&cassandraprotocol.HeaderFlagWarning > 0 {
-		if warnings, err = primitives.ReadStringList(source); err != nil {
-			err = fmt.Errorf("cannot decode body warnings: %w", err)
+	if header.Flags&cassandraprotocol.HeaderFlagCustomPayload > 0 {
+		if body.CustomPayload, err = primitives.ReadBytesMap(source); err != nil {
+			return nil, fmt.Errorf("cannot decode body custom payload: %w", err)
 		}
 	}
-	if err == nil {
-		if decoder, found := c.codecs[opCode]; !found {
-			err = errors.New(fmt.Sprintf("unsupported opcode %d", opCode))
-		} else if message, err = decoder.Decode(source, version); err != nil {
-			err = fmt.Errorf("cannot decode body message: %w", err)
+	if header.IsResponse && header.Flags&cassandraprotocol.HeaderFlagWarning > 0 {
+		if body.Warnings, err = primitives.ReadStringList(source); err != nil {
+			return nil, fmt.Errorf("cannot decode body warnings: %w", err)
 		}
 	}
-	return tracingId, customPayload, warnings, message, err
+	if decoder, found := c.codecs[header.OpCode]; !found {
+		return nil, errors.New(fmt.Sprintf("unsupported opcode %d", header.OpCode))
+	} else if body.Message, err = decoder.Decode(source, header.Version); err != nil {
+		return nil, fmt.Errorf("cannot decode body message: %w", err)
+	}
+	return body, err
+}
+
+// DiscardBody discards the contents of a frame body. It is illegal to call this method before calling
+// DecodeHeader.
+func (c *Codec) DiscardBody(bodyLength int32, source io.Reader) (err error) {
+	count := int64(bodyLength)
+	switch r := source.(type) {
+	case io.Seeker:
+		_, err = r.Seek(count, io.SeekCurrent)
+	default:
+		_, err = io.CopyN(ioutil.Discard, r, count)
+	}
+	return err
+}
+
+// DecompressBody decompresses a compressed frame body and returns a new bytes.Buffer containing the decompressed body.
+// The original io.Reader will be fully consumed and should be discarded after calling this method.
+func (c *Codec) DecompressBody(compressedBodyLength int32, source io.Reader) (*bytes.Buffer, error) {
+	compressedBody := bytes.Buffer{}
+	count := int64(compressedBodyLength)
+	if actualBodyLength, err := io.CopyN(&compressedBody, source, count); err != nil {
+		return nil, err
+	} else if count != actualBodyLength {
+		return nil, errors.New(fmt.Sprintf(
+			"declared body length in header (%d) does not match actual body length (%d)",
+			compressedBodyLength,
+			actualBodyLength))
+	}
+	if decompressedBody, err := c.compressor.Decompress(&compressedBody); err != nil {
+		return nil, fmt.Errorf("cannot decompress frame body: %w", err)
+	} else {
+		return decompressedBody, nil
+	}
 }

--- a/cassandraprotocol/frame/frame.go
+++ b/cassandraprotocol/frame/frame.go
@@ -133,14 +133,14 @@ func NewResponseFrame(
 	}, nil
 }
 
-func (f Frame) String() string {
+func (f *Frame) String() string {
 	return fmt.Sprintf("{header: %v, body: %v}", f.Header, f.Body)
 }
 
-func (h Header) String() string {
+func (h *Header) String() string {
 	return fmt.Sprintf("{version: %v, stream id: %v, tracing: %v}", h.Version, h.StreamId, h.TracingRequested)
 }
 
-func (b Body) String() string {
+func (b *Body) String() string {
 	return fmt.Sprintf("{tracing id: %v, payload: %v, warnings: %v, message: %v}", b.TracingId, b.CustomPayload, b.Warnings, b.Message)
 }

--- a/cassandraprotocol/frame/frame.go
+++ b/cassandraprotocol/frame/frame.go
@@ -1,6 +1,7 @@
 package frame
 
 import (
+	"bytes"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -37,19 +38,25 @@ func (f *Frame) Flags(compress bool) cassandraprotocol.HeaderFlag {
 	return flags
 }
 
-// IsCompressible returns true if the frame contains a body that can be compressed. Bodies containing STARTUP and
-// OPTIONS messages should indeed never be compressed, even if compression is in use.
+// IsCompressible returns true if the frame contains a body that can be compressed. Bodies containing STARTUP
+// should never be compressed. Empty messages like OPTIONS and READY also should not be compressed,
+// even if compression is in use.
 func (f *Frame) IsCompressible() bool {
 	opCode := f.Body.Message.GetOpCode()
-	return opCode != cassandraprotocol.OpCodeStartup && opCode != cassandraprotocol.OpCodeOptions
+	// STARTUP should never be compressed as per protocol specs
+	return opCode != cassandraprotocol.OpCodeStartup &&
+		// OPTIONS and READY are empty and as such do not benefit from compression
+		opCode != cassandraprotocol.OpCodeOptions &&
+		opCode != cassandraprotocol.OpCodeReady
 }
 
 // Dump encodes and dumps the contents of this frame, for debugging purposes.
 func (f *Frame) Dump() (string, error) {
-	if encoded, err := NewCodec().Encode(f); err != nil {
+	buffer := bytes.Buffer{}
+	if err := NewCodec().Encode(f, &buffer); err != nil {
 		return "", err
 	} else {
-		return hex.Dump(encoded.Bytes()), nil
+		return hex.Dump(buffer.Bytes()), nil
 	}
 }
 
@@ -87,16 +94,17 @@ func NewRequestFrame(
 	if message.IsResponse() {
 		return nil, errors.New("message is not a request: opcode " + string(message.GetOpCode()))
 	}
-	return newFrame(
-		&Header{
+	return &Frame{
+		Header: &Header{
 			Version:          version,
 			StreamId:         streamId,
 			TracingRequested: tracing,
 		},
-		&Body{
+		Body: &Body{
 			CustomPayload: customPayload,
 			Message:       message,
-		})
+		},
+	}, nil
 }
 
 func NewResponseFrame(
@@ -110,43 +118,29 @@ func NewResponseFrame(
 	if !message.IsResponse() {
 		return nil, errors.New("message is not a response: opcode " + string(message.GetOpCode()))
 	}
-	return newFrame(
-		&Header{
+	return &Frame{
+		Header: &Header{
 			Version:          version,
 			StreamId:         streamId,
 			TracingRequested: tracingId != nil,
 		},
-		&Body{
+		Body: &Body{
 			TracingId:     tracingId,
 			CustomPayload: customPayload,
 			Warnings:      warnings,
 			Message:       message,
-		})
+		},
+	}, nil
 }
 
-func newFrame(header *Header, body *Body) (*Frame, error) {
-	// Check header and body global conformity with protocol specs here.
-	// Body message conformity with protocol specs will be tested by the message codecs.
-	if header.Version < cassandraprotocol.ProtocolVersionMin || header.Version > cassandraprotocol.ProtocolVersionMax {
-		return nil, fmt.Errorf("unsupported protocol version: %v", header.Version)
-	}
-	if body.CustomPayload != nil && header.Version < cassandraprotocol.ProtocolVersion4 {
-		return nil, errors.New("custom payloads require protocol version 4 or higher")
-	}
-	if body.Warnings != nil && header.Version < cassandraprotocol.ProtocolVersion4 {
-		return nil, errors.New("warnings require protocol version 4 or higher")
-	}
-	return &Frame{header, body}, nil
-}
-
-func (f *Frame) String() string {
+func (f Frame) String() string {
 	return fmt.Sprintf("{header: %v, body: %v}", f.Header, f.Body)
 }
 
-func (h *Header) String() string {
+func (h Header) String() string {
 	return fmt.Sprintf("{version: %v, stream id: %v, tracing: %v}", h.Version, h.StreamId, h.TracingRequested)
 }
 
-func (b *Body) String() string {
+func (b Body) String() string {
 	return fmt.Sprintf("{tracing id: %v, payload: %v, warnings: %v, message: %v}", b.TracingId, b.CustomPayload, b.Warnings, b.Message)
 }

--- a/cassandraprotocol/message/ready.go
+++ b/cassandraprotocol/message/ready.go
@@ -11,7 +11,7 @@ type Ready struct {
 }
 
 func (m *Ready) IsResponse() bool {
-	return false
+	return true
 }
 
 func (m *Ready) GetOpCode() cassandraprotocol.OpCode {

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -63,11 +64,12 @@ func testMessage(originalFrame *frame.Frame, useJson bool) {
 		fmt.Printf("original frame:\n%v\n", originalFrame)
 	}
 	codec := frame.NewCodec()
-	if encodedFrame, err := codec.Encode(originalFrame); err != nil {
+	encodedFrame := bytes.Buffer{}
+	if err := codec.Encode(originalFrame, &encodedFrame); err != nil {
 		panic(err)
 	} else {
 		fmt.Print("encoded frame:\n", hex.Dump(encodedFrame.Bytes()))
-		if decodedFrame, err := codec.Decode(encodedFrame); err != nil {
+		if decodedFrame, err := codec.Decode(&encodedFrame); err != nil {
 			panic(err)
 		} else {
 			if useJson {


### PR DESCRIPTION
This PR also:

1. Exposes the `DecodeHeader`, `DecodeBody` and `DecompressBody` methods of `frame.Codec`. 
2. It also introduces a new struct `RawHeader` and a new `DiscardBody` method. These changes aim to make it possible to only decode the header of a received frame.
3. Fixes lz4 compression, including compression for empty messages.