### PR TITLE
Add EncodeRaw and DecodeRaw

### DIFF
--- a/cassandraprotocol/client/connection.go
+++ b/cassandraprotocol/client/connection.go
@@ -11,15 +11,15 @@ type CqlConnection struct {
 }
 
 func (c *CqlConnection) Send(f *frame.Frame) error {
-	return c.codec.Encode(f, c.conn)
+	return c.codec.EncodeFrame(f, c.conn)
 }
 
 func (c *CqlConnection) Receive() (*frame.Frame, error) {
-	return c.codec.Decode(c.conn)
+	return c.codec.DecodeFrame(c.conn)
 }
 
 func (c *CqlConnection) ReceiveHeader() (header *frame.RawHeader, err error) {
-	if header, err = c.codec.DecodeHeader(c.conn); err != nil {
+	if header, err = c.codec.DecodeRawHeader(c.conn); err != nil {
 		return nil, err
 	} else if err = c.codec.DiscardBody(header.BodyLength, c.conn); err != nil {
 		return nil, err

--- a/cassandraprotocol/frame/codec_test.go
+++ b/cassandraprotocol/frame/codec_test.go
@@ -59,6 +59,32 @@ func TestFrameEncodeDecode(t *testing.T) {
 	}
 }
 
+func TestRawFrameEncodeDecode(t *testing.T) {
+	codec := NewCodec()
+	tests := []struct {
+		name  string
+		frame *Frame
+		err   error
+	}{
+		{"request", request, nil},
+		{"response", response, nil},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var rawFrame *RawFrame
+			var err error
+			rawFrame, err = codec.ConvertToRawFrame(test.frame)
+			assert.Equal(t, test.err, err)
+			encodedFrame := &bytes.Buffer{}
+			err = codec.EncodeRaw(rawFrame, encodedFrame)
+			assert.Equal(t, test.err, err)
+			decodedFrame, err := codec.DecodeRaw(encodedFrame)
+			assert.Equal(t, test.err, err)
+			assert.Equal(t, rawFrame, decodedFrame)
+		})
+	}
+}
+
 func TestFrameEncodeDecodeWithCompression(t *testing.T) {
 	codecs := map[string]*Codec{
 		"lz4":    NewCodec(WithCompressor(compression.Lz4Compressor{})),
@@ -86,6 +112,75 @@ func TestFrameEncodeDecodeWithCompression(t *testing.T) {
 					}
 				})
 			}
+		})
+	}
+}
+
+func TestRawFrameEncodeDecodeWithCompression(t *testing.T) {
+	codecs := map[string]*Codec{
+		"lz4":    NewCodec(WithCompressor(compression.Lz4Compressor{})),
+		"snappy": NewCodec(WithCompressor(compression.SnappyCompressor{})),
+	}
+	tests := []struct {
+		name  string
+		frame *Frame
+		err   error
+	}{
+		{"request", request, nil},
+		{"response", response, nil},
+	}
+	for algorithm, codec := range codecs {
+		t.Run(algorithm, func(t *testing.T) {
+			for _, test := range tests {
+				t.Run(test.name, func(t *testing.T) {
+					var rawFrame *RawFrame
+					var err error
+					rawFrame, err = codec.ConvertToRawFrame(test.frame)
+					assert.Equal(t, test.err, err)
+					encodedFrame := &bytes.Buffer{}
+					err = codec.EncodeRaw(rawFrame, encodedFrame)
+					assert.Equal(t, test.err, err)
+					decodedFrame, err := codec.DecodeRaw(encodedFrame)
+					assert.Equal(t, test.err, err)
+					assert.Equal(t, rawFrame, decodedFrame)
+				})
+			}
+		})
+	}
+}
+
+func TestConvertToRawFrame(t *testing.T) {
+	codec := NewCodec()
+	tests := []struct {
+		name  string
+		frame *Frame
+		err   error
+	}{
+		{"request", request, nil},
+		{"response", response, nil},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var rawFrame *RawFrame
+			var err error
+			rawFrame, err = codec.ConvertToRawFrame(test.frame)
+			assert.Equal(t, test.err, err)
+			assert.Equal(t, test.frame.Header.StreamId, rawFrame.Header.StreamId)
+			assert.Equal(t, test.frame.Header.Version, rawFrame.Header.Version)
+			if test.frame.Header.TracingRequested {
+				assert.Equal(t, cassandraprotocol.HeaderFlagTracing, rawFrame.Header.Flags & cassandraprotocol.HeaderFlagTracing)
+			} else {
+				assert.Equal(t, 0, rawFrame.Header.Flags & cassandraprotocol.HeaderFlagTracing)
+			}
+			assert.Equal(t, test.frame.Body.Message.GetOpCode(), rawFrame.Header.OpCode)
+			assert.Equal(t, test.frame.Body.Message.IsResponse(), rawFrame.Header.IsResponse)
+
+			encodedFrame := &bytes.Buffer{}
+			err = codec.Encode(test.frame, encodedFrame)
+			assert.Equal(t, test.err, err)
+			encodedBody := encodedFrame.Bytes()[9:]
+			assert.Equal(t, encodedBody, rawFrame.Body)
+			assert.Equal(t, int32(len(encodedBody)), rawFrame.Header.BodyLength)
 		})
 	}
 }

--- a/cassandraprotocol/frame/codec_test.go
+++ b/cassandraprotocol/frame/codec_test.go
@@ -165,22 +165,22 @@ func TestConvertToRawFrame(t *testing.T) {
 			var err error
 			rawFrame, err = codec.ConvertToRawFrame(test.frame)
 			assert.Equal(t, test.err, err)
-			assert.Equal(t, test.frame.Header.StreamId, rawFrame.Header.StreamId)
-			assert.Equal(t, test.frame.Header.Version, rawFrame.Header.Version)
+			assert.Equal(t, test.frame.Header.StreamId, rawFrame.RawHeader.StreamId)
+			assert.Equal(t, test.frame.Header.Version, rawFrame.RawHeader.Version)
 			if test.frame.Header.TracingRequested {
-				assert.Equal(t, cassandraprotocol.HeaderFlagTracing, rawFrame.Header.Flags & cassandraprotocol.HeaderFlagTracing)
+				assert.Equal(t, cassandraprotocol.HeaderFlagTracing, rawFrame.RawHeader.Flags & cassandraprotocol.HeaderFlagTracing)
 			} else {
-				assert.Equal(t, 0, rawFrame.Header.Flags & cassandraprotocol.HeaderFlagTracing)
+				assert.Equal(t, 0, rawFrame.RawHeader.Flags & cassandraprotocol.HeaderFlagTracing)
 			}
-			assert.Equal(t, test.frame.Body.Message.GetOpCode(), rawFrame.Header.OpCode)
-			assert.Equal(t, test.frame.Body.Message.IsResponse(), rawFrame.Header.IsResponse)
+			assert.Equal(t, test.frame.Body.Message.GetOpCode(), rawFrame.RawHeader.OpCode)
+			assert.Equal(t, test.frame.Body.Message.IsResponse(), rawFrame.RawHeader.IsResponse)
 
 			encodedFrame := &bytes.Buffer{}
 			err = codec.EncodeFrame(test.frame, encodedFrame)
 			assert.Equal(t, test.err, err)
 			encodedBody := encodedFrame.Bytes()[9:]
-			assert.Equal(t, encodedBody, rawFrame.Body)
-			assert.Equal(t, int32(len(encodedBody)), rawFrame.Header.BodyLength)
+			assert.Equal(t, encodedBody, rawFrame.RawBody)
+			assert.Equal(t, int32(len(encodedBody)), rawFrame.RawHeader.BodyLength)
 		})
 	}
 }

--- a/cassandraprotocol/frame/codec_test.go
+++ b/cassandraprotocol/frame/codec_test.go
@@ -48,9 +48,9 @@ func TestFrameEncodeDecode(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			encodedFrame := bytes.Buffer{}
-			if err := codec.Encode(test.frame, &encodedFrame); err != nil {
+			if err := codec.EncodeFrame(test.frame, &encodedFrame); err != nil {
 				assert.Equal(t, test.err, err)
-			} else if decodedFrame, err := codec.Decode(&encodedFrame); err != nil {
+			} else if decodedFrame, err := codec.DecodeFrame(&encodedFrame); err != nil {
 				assert.Equal(t, test.err, err)
 			} else {
 				assert.Equal(t, test.frame, decodedFrame)
@@ -76,9 +76,9 @@ func TestRawFrameEncodeDecode(t *testing.T) {
 			rawFrame, err = codec.ConvertToRawFrame(test.frame)
 			assert.Equal(t, test.err, err)
 			encodedFrame := &bytes.Buffer{}
-			err = codec.EncodeRaw(rawFrame, encodedFrame)
+			err = codec.EncodeRawFrame(rawFrame, encodedFrame)
 			assert.Equal(t, test.err, err)
-			decodedFrame, err := codec.DecodeRaw(encodedFrame)
+			decodedFrame, err := codec.DecodeRawFrame(encodedFrame)
 			assert.Equal(t, test.err, err)
 			assert.Equal(t, rawFrame, decodedFrame)
 		})
@@ -103,9 +103,9 @@ func TestFrameEncodeDecodeWithCompression(t *testing.T) {
 			for _, test := range tests {
 				t.Run(test.name, func(t *testing.T) {
 					encodedFrame := bytes.Buffer{}
-					if err := codec.Encode(test.frame, &encodedFrame); err != nil {
+					if err := codec.EncodeFrame(test.frame, &encodedFrame); err != nil {
 						assert.Equal(t, test.err, err)
-					} else if decodedFrame, err := codec.Decode(&encodedFrame); err != nil {
+					} else if decodedFrame, err := codec.DecodeFrame(&encodedFrame); err != nil {
 						assert.Equal(t, test.err, err)
 					} else {
 						assert.Equal(t, test.frame, decodedFrame)
@@ -138,9 +138,9 @@ func TestRawFrameEncodeDecodeWithCompression(t *testing.T) {
 					rawFrame, err = codec.ConvertToRawFrame(test.frame)
 					assert.Equal(t, test.err, err)
 					encodedFrame := &bytes.Buffer{}
-					err = codec.EncodeRaw(rawFrame, encodedFrame)
+					err = codec.EncodeRawFrame(rawFrame, encodedFrame)
 					assert.Equal(t, test.err, err)
-					decodedFrame, err := codec.DecodeRaw(encodedFrame)
+					decodedFrame, err := codec.DecodeRawFrame(encodedFrame)
 					assert.Equal(t, test.err, err)
 					assert.Equal(t, rawFrame, decodedFrame)
 				})
@@ -176,7 +176,7 @@ func TestConvertToRawFrame(t *testing.T) {
 			assert.Equal(t, test.frame.Body.Message.IsResponse(), rawFrame.Header.IsResponse)
 
 			encodedFrame := &bytes.Buffer{}
-			err = codec.Encode(test.frame, encodedFrame)
+			err = codec.EncodeFrame(test.frame, encodedFrame)
 			assert.Equal(t, test.err, err)
 			encodedBody := encodedFrame.Bytes()[9:]
 			assert.Equal(t, encodedBody, rawFrame.Body)

--- a/cassandraprotocol/frame/decoder.go
+++ b/cassandraprotocol/frame/decoder.go
@@ -33,7 +33,7 @@ func (c *Codec) DecodeRawFrame(source io.Reader) (*RawFrame, error) {
 	} else if body, err := c.DecodeRawBody(rawHeader.BodyLength, source); err != nil {
 		return nil, fmt.Errorf("cannot read frame body: %w", err)
 	} else {
-		return &RawFrame{Header: rawHeader, Body: body}, nil
+		return &RawFrame{RawHeader: rawHeader, RawBody: body}, nil
 	}
 }
 

--- a/cassandraprotocol/frame/encoder.go
+++ b/cassandraprotocol/frame/encoder.go
@@ -36,12 +36,10 @@ func (c *Codec) EncodeRaw(frame *RawFrame, dest io.Writer) error {
 		return fmt.Errorf("unsupported protocol version: %v", version)
 	}
 
-	// Encode header
 	if err := c.encodeRawHeader(frame.Header, dest); err != nil {
 		return fmt.Errorf("cannot encode raw header: %w", err)
 	}
 
-	// Append body
 	if bytesWritten, err := dest.Write(frame.Body); err != nil {
 		return fmt.Errorf(
 			"cannot write body: %w, body length: %d, bytes written: %d", err, len(frame.Body), bytesWritten)
@@ -115,11 +113,11 @@ func (c *Codec) encodeFrameCompressed(frame *Frame, dest io.Writer) error {
 		return fmt.Errorf("cannot encode and compress body: %w", err)
 	}
 	compressedBodyLength := compressedBody.Len()
-	// 3) Encode header
+
 	if err := c.encodeHeader(frame, compressedBodyLength, dest); err != nil {
 		return fmt.Errorf("cannot encode frame header: %w", err)
 	}
-	// 4) join header and compressed body
+
 	if _, err := compressedBody.WriteTo(dest); err != nil {
 		return fmt.Errorf("cannot concat frame body to frame header: %w", err)
 	}
@@ -128,7 +126,7 @@ func (c *Codec) encodeFrameCompressed(frame *Frame, dest io.Writer) error {
 
 func (c *Codec) encodeBodyCompressed(frame *Frame) (*bytes.Buffer, error) {
 	var err error
-	// 1) Encode uncompressed body
+
 	var uncompressedBodyLength int
 	if uncompressedBodyLength, err = c.uncompressedBodyLength(frame); err != nil {
 		return nil, fmt.Errorf("cannot compute length of uncompressed message body: %w", err)
@@ -137,7 +135,7 @@ func (c *Codec) encodeBodyCompressed(frame *Frame) (*bytes.Buffer, error) {
 	if err = c.encodeBodyUncompressed(frame, uncompressedBody); err != nil {
 		return nil, fmt.Errorf("cannot encode frame body: %w", err)
 	}
-	// 2) Compress body
+
 	var compressedBody *bytes.Buffer
 	if compressedBody, err = c.compressor.Compress(uncompressedBody); err != nil {
 		return nil, fmt.Errorf("cannot compress frame body: %w", err)

--- a/cassandraprotocol/frame/encoder.go
+++ b/cassandraprotocol/frame/encoder.go
@@ -10,8 +10,8 @@ import (
 	"io"
 )
 
-// Encode encodes the entire frame, compressing the body if needed.
-func (c *Codec) Encode(frame *Frame, dest io.Writer) error {
+// EncodeFrame encodes the entire frame, compressing the body if needed.
+func (c *Codec) EncodeFrame(frame *Frame, dest io.Writer) error {
 	version := frame.Header.Version
 	if version < cassandraprotocol.ProtocolVersionMin || version > cassandraprotocol.ProtocolVersionMax {
 		return fmt.Errorf("unsupported protocol version: %v", version)
@@ -29,8 +29,8 @@ func (c *Codec) Encode(frame *Frame, dest io.Writer) error {
 	}
 }
 
-// EncodeRaw encodes the header and writes the body as raw bytes.
-func (c *Codec) EncodeRaw(frame *RawFrame, dest io.Writer) error {
+// EncodeRawFrame encodes the header and writes the body as raw bytes.
+func (c *Codec) EncodeRawFrame(frame *RawFrame, dest io.Writer) error {
 	version := frame.Header.Version
 	if version < cassandraprotocol.ProtocolVersionMin || version > cassandraprotocol.ProtocolVersionMax {
 		return fmt.Errorf("unsupported protocol version: %v", version)

--- a/cassandraprotocol/frame/encoder.go
+++ b/cassandraprotocol/frame/encoder.go
@@ -31,18 +31,18 @@ func (c *Codec) EncodeFrame(frame *Frame, dest io.Writer) error {
 
 // EncodeRawFrame encodes the header and writes the body as raw bytes.
 func (c *Codec) EncodeRawFrame(frame *RawFrame, dest io.Writer) error {
-	version := frame.Header.Version
+	version := frame.RawHeader.Version
 	if version < cassandraprotocol.ProtocolVersionMin || version > cassandraprotocol.ProtocolVersionMax {
 		return fmt.Errorf("unsupported protocol version: %v", version)
 	}
 
-	if err := c.encodeRawHeader(frame.Header, dest); err != nil {
+	if err := c.encodeRawHeader(frame.RawHeader, dest); err != nil {
 		return fmt.Errorf("cannot encode raw header: %w", err)
 	}
 
-	if bytesWritten, err := dest.Write(frame.Body); err != nil {
+	if bytesWritten, err := dest.Write(frame.RawBody); err != nil {
 		return fmt.Errorf(
-			"cannot write body: %w, body length: %d, bytes written: %d", err, len(frame.Body), bytesWritten)
+			"cannot write body: %w, body length: %d, bytes written: %d", err, len(frame.RawBody), bytesWritten)
 	}
 
 	return nil
@@ -66,8 +66,8 @@ func (c *Codec) ConvertToRawFrame(frame *Frame) (*RawFrame, error) {
 
 	bodyBytes := body.Bytes()
 	return &RawFrame{
-		Header: c.convertToRawHeader(frame, int32(len(bodyBytes))),
-		Body:   bodyBytes,
+		RawHeader: c.convertToRawHeader(frame, int32(len(bodyBytes))),
+		RawBody:   bodyBytes,
 	}, nil
 }
 

--- a/cassandraprotocol/frame/encoder.go
+++ b/cassandraprotocol/frame/encoder.go
@@ -10,6 +10,7 @@ import (
 	"io"
 )
 
+// Encode encodes the entire frame, compressing the body if needed.
 func (c *Codec) Encode(frame *Frame, dest io.Writer) error {
 	version := frame.Header.Version
 	if version < cassandraprotocol.ProtocolVersionMin || version > cassandraprotocol.ProtocolVersionMax {
@@ -28,6 +29,7 @@ func (c *Codec) Encode(frame *Frame, dest io.Writer) error {
 	}
 }
 
+// EncodeRaw encodes the header and writes the body as raw bytes.
 func (c *Codec) EncodeRaw(frame *RawFrame, dest io.Writer) error {
 	version := frame.Header.Version
 	if version < cassandraprotocol.ProtocolVersionMin || version > cassandraprotocol.ProtocolVersionMax {
@@ -35,16 +37,51 @@ func (c *Codec) EncodeRaw(frame *RawFrame, dest io.Writer) error {
 	}
 
 	// Encode header
-	if err := c.encodeRawHeader(frame.Header, len(frame.Body), dest); err != nil {
-		return err
+	if err := c.encodeRawHeader(frame.Header, dest); err != nil {
+		return fmt.Errorf("cannot encode raw header: %w", err)
 	}
 
 	// Append body
-	if _, err := dest.Write(frame.Body); err != nil {
-		return err
+	if bytesWritten, err := dest.Write(frame.Body); err != nil {
+		return fmt.Errorf(
+			"cannot write body: %w, body length: %d, bytes written: %d", err, len(frame.Body), bytesWritten)
 	}
 
 	return nil
+}
+
+// ConvertToRawFrame converts a Frame to a RawFrame, encoding the body and compressing it if necessary.
+func (c *Codec) ConvertToRawFrame(frame *Frame) (*RawFrame, error) {
+	var body *bytes.Buffer
+	var err error
+
+	if c.compressor != nil && frame.IsCompressible() {
+		body, err = c.encodeBodyCompressed(frame)
+	} else {
+		body = &bytes.Buffer{}
+		err = c.encodeBodyUncompressed(frame, body)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("cannot encode body: %w", err)
+	}
+
+	bodyBytes := body.Bytes()
+	return &RawFrame{
+		Header: c.convertToRawHeader(frame, int32(len(bodyBytes))),
+		Body:   bodyBytes,
+	}, nil
+}
+
+func (c *Codec) convertToRawHeader(frame *Frame, bodyLength int32) *RawHeader {
+	return &RawHeader{
+		IsResponse: frame.Body.Message.IsResponse(),
+		Version:    frame.Header.Version,
+		Flags:      frame.Flags(c.compressor != nil),
+		StreamId:   frame.Header.StreamId,
+		OpCode:     frame.Body.Message.GetOpCode(),
+		BodyLength: bodyLength,
+	}
 }
 
 func (c *Codec) findEncoder(frame *Frame) (encoder message.Encoder, err error) {
@@ -72,24 +109,14 @@ func (c *Codec) encodeFrameUncompressed(frame *Frame, dest io.Writer) error {
 }
 
 func (c *Codec) encodeFrameCompressed(frame *Frame, dest io.Writer) error {
-	var err error
-	// 1) Encode uncompressed body
-	var uncompressedBodyLength int
-	if uncompressedBodyLength, err = c.uncompressedBodyLength(frame); err != nil {
-		return fmt.Errorf("cannot compute length of uncompressed message body: %w", err)
-	}
-	uncompressedBody := bytes.NewBuffer(make([]byte, 0, uncompressedBodyLength))
-	if err = c.encodeBodyUncompressed(frame, uncompressedBody); err != nil {
-		return fmt.Errorf("cannot encode frame body: %w", err)
-	}
-	// 2) Compress body
 	var compressedBody *bytes.Buffer
-	if compressedBody, err = c.compressor.Compress(uncompressedBody); err != nil {
-		return fmt.Errorf("cannot compress frame body: %w", err)
+	var err error
+	if compressedBody, err = c.encodeBodyCompressed(frame); err != nil {
+		return fmt.Errorf("cannot encode and compress body: %w", err)
 	}
 	compressedBodyLength := compressedBody.Len()
 	// 3) Encode header
-	if err = c.encodeHeader(frame, compressedBodyLength, dest); err != nil {
+	if err := c.encodeHeader(frame, compressedBodyLength, dest); err != nil {
 		return fmt.Errorf("cannot encode frame header: %w", err)
 	}
 	// 4) join header and compressed body
@@ -97,6 +124,26 @@ func (c *Codec) encodeFrameCompressed(frame *Frame, dest io.Writer) error {
 		return fmt.Errorf("cannot concat frame body to frame header: %w", err)
 	}
 	return nil
+}
+
+func (c *Codec) encodeBodyCompressed(frame *Frame) (*bytes.Buffer, error) {
+	var err error
+	// 1) Encode uncompressed body
+	var uncompressedBodyLength int
+	if uncompressedBodyLength, err = c.uncompressedBodyLength(frame); err != nil {
+		return nil, fmt.Errorf("cannot compute length of uncompressed message body: %w", err)
+	}
+	uncompressedBody := bytes.NewBuffer(make([]byte, 0, uncompressedBodyLength))
+	if err = c.encodeBodyUncompressed(frame, uncompressedBody); err != nil {
+		return nil, fmt.Errorf("cannot encode frame body: %w", err)
+	}
+	// 2) Compress body
+	var compressedBody *bytes.Buffer
+	if compressedBody, err = c.compressor.Compress(uncompressedBody); err != nil {
+		return nil, fmt.Errorf("cannot compress frame body: %w", err)
+	}
+
+	return compressedBody, nil
 }
 
 func (c *Codec) encodeHeader(frame *Frame, bodyLength int, dest io.Writer) error {
@@ -120,23 +167,23 @@ func (c *Codec) encodeHeader(frame *Frame, bodyLength int, dest io.Writer) error
 	return nil
 }
 
-func (c *Codec) encodeRawHeader(rawHeader *RawHeader, bodyLength int, dest io.Writer) error {
+func (c *Codec) encodeRawHeader(rawHeader *RawHeader, dest io.Writer) error {
 	versionAndDirection := rawHeader.Version
 	if rawHeader.IsResponse {
 		versionAndDirection |= 0b1000_0000
 	}
 	if err := primitives.WriteByte(versionAndDirection, dest); err != nil {
-		return err
+		return fmt.Errorf("cannot encode header version and direction: %w", err)
 	}
 	flags := rawHeader.Flags
 	if err := primitives.WriteByte(flags, dest); err != nil {
-		return err
+		return fmt.Errorf("cannot encode header flags: %w", err)
 	} else if err = primitives.WriteShort(uint16(rawHeader.StreamId), dest); err != nil {
-		return err
+		return fmt.Errorf("cannot encode header stream id: %w", err)
 	} else if err = primitives.WriteByte(rawHeader.OpCode, dest); err != nil {
-		return err
-	} else if err = primitives.WriteInt(int32(bodyLength), dest); err != nil {
-		return err
+		return fmt.Errorf("cannot encode header opcode: %w", err)
+	} else if err = primitives.WriteInt(rawHeader.BodyLength, dest); err != nil {
+		return fmt.Errorf("cannot encode header body length: %w", err)
 	}
 	return nil
 }

--- a/cassandraprotocol/frame/frame.go
+++ b/cassandraprotocol/frame/frame.go
@@ -48,7 +48,7 @@ func (f *Frame) IsCompressible() bool {
 // Dump encodes and dumps the contents of this frame, for debugging purposes.
 func (f *Frame) Dump() (string, error) {
 	buffer := bytes.Buffer{}
-	if err := NewCodec().Encode(f, &buffer); err != nil {
+	if err := NewCodec().EncodeFrame(f, &buffer); err != nil {
 		return "", err
 	} else {
 		return hex.Dump(buffer.Bytes()), nil

--- a/cassandraprotocol/frame/frame.go
+++ b/cassandraprotocol/frame/frame.go
@@ -42,12 +42,7 @@ func (f *Frame) Flags(compress bool) cassandraprotocol.HeaderFlag {
 // should never be compressed. Empty messages like OPTIONS and READY also should not be compressed,
 // even if compression is in use.
 func (f *Frame) IsCompressible() bool {
-	opCode := f.Body.Message.GetOpCode()
-	// STARTUP should never be compressed as per protocol specs
-	return opCode != cassandraprotocol.OpCodeStartup &&
-		// OPTIONS and READY are empty and as such do not benefit from compression
-		opCode != cassandraprotocol.OpCodeOptions &&
-		opCode != cassandraprotocol.OpCodeReady
+	return isCompressible(f.Body.Message.GetOpCode())
 }
 
 // Dump encodes and dumps the contents of this frame, for debugging purposes.
@@ -143,4 +138,12 @@ func (h *Header) String() string {
 
 func (b *Body) String() string {
 	return fmt.Sprintf("{tracing id: %v, payload: %v, warnings: %v, message: %v}", b.TracingId, b.CustomPayload, b.Warnings, b.Message)
+}
+
+func isCompressible(opCode cassandraprotocol.OpCode) bool {
+	// STARTUP should never be compressed as per protocol specs
+	return opCode != cassandraprotocol.OpCodeStartup &&
+		// OPTIONS and READY are empty and as such do not benefit from compression
+		opCode != cassandraprotocol.OpCodeOptions &&
+		opCode != cassandraprotocol.OpCodeReady
 }

--- a/cassandraprotocol/frame/rawframe.go
+++ b/cassandraprotocol/frame/rawframe.go
@@ -7,8 +7,8 @@ import (
 
 // A low-level representation of a frame, where the body is not decoded.
 type RawFrame struct {
-	Header *RawHeader
-	Body   []byte
+	RawHeader *RawHeader
+	RawBody   []byte
 }
 
 // A low-level representation of a frame header, as it is parsed from an encoded frame.
@@ -25,7 +25,7 @@ type RawHeader struct {
 // should never be compressed. Empty messages like OPTIONS and READY also should not be compressed,
 // even if compression is in use.
 func (f *RawFrame) IsCompressible() bool {
-	return isCompressible(f.Header.OpCode)
+	return isCompressible(f.RawHeader.OpCode)
 }
 
 func (r *RawHeader) String() string {
@@ -34,5 +34,5 @@ func (r *RawHeader) String() string {
 }
 
 func (f *RawFrame) String() string {
-	return fmt.Sprintf("{header: %v, body: %v}", f.Header, f.Body)
+	return fmt.Sprintf("{header: %v, body: %v}", f.RawHeader, f.RawBody)
 }

--- a/cassandraprotocol/frame/rawframe.go
+++ b/cassandraprotocol/frame/rawframe.go
@@ -2,11 +2,35 @@ package frame
 
 import (
 	"fmt"
+	"github.com/datastax/go-cassandra-native-protocol/cassandraprotocol"
 )
 
+// A low-level representation of a frame, where the body is not decoded.
 type RawFrame struct {
 	Header *RawHeader
 	Body   []byte
+}
+
+// A low-level representation of a frame header, as it is parsed from an encoded frame.
+type RawHeader struct {
+	IsResponse bool
+	Version    cassandraprotocol.ProtocolVersion
+	Flags      cassandraprotocol.HeaderFlag
+	StreamId   int16
+	OpCode     cassandraprotocol.OpCode
+	BodyLength int32
+}
+
+// IsCompressible returns true if the frame contains a body that can be compressed. Bodies containing STARTUP
+// should never be compressed. Empty messages like OPTIONS and READY also should not be compressed,
+// even if compression is in use.
+func (f *RawFrame) IsCompressible() bool {
+	return isCompressible(f.Header.OpCode)
+}
+
+func (r *RawHeader) String() string {
+	return fmt.Sprintf("{response: %v, version: %v, flags: %08b, stream id: %v, opcode: %v, body length: %v}",
+		r.IsResponse, r.Version, r.Flags, r.StreamId, r.OpCode, r.BodyLength)
 }
 
 func (f *RawFrame) String() string {

--- a/cassandraprotocol/frame/rawframe.go
+++ b/cassandraprotocol/frame/rawframe.go
@@ -1,0 +1,14 @@
+package frame
+
+import (
+	"fmt"
+)
+
+type RawFrame struct {
+	Header *RawHeader
+	Body   []byte
+}
+
+func (f *RawFrame) String() string {
+	return fmt.Sprintf("{header: %v, body: %v}", f.Header, f.Body)
+}

--- a/cassandraprotocol/message/query.go
+++ b/cassandraprotocol/message/query.go
@@ -17,11 +17,11 @@ func (q *Query) String() string {
 	return fmt.Sprintf("QUERY %s", q.Query)
 }
 
-func (q Query) IsResponse() bool {
+func (q *Query) IsResponse() bool {
 	return false
 }
 
-func (q Query) GetOpCode() cassandraprotocol.OpCode {
+func (q *Query) GetOpCode() cassandraprotocol.OpCode {
 	return cassandraprotocol.OpCodeQuery
 }
 

--- a/main.go
+++ b/main.go
@@ -65,11 +65,11 @@ func testMessage(originalFrame *frame.Frame, useJson bool) {
 	}
 	codec := frame.NewCodec()
 	encodedFrame := bytes.Buffer{}
-	if err := codec.Encode(originalFrame, &encodedFrame); err != nil {
+	if err := codec.EncodeFrame(originalFrame, &encodedFrame); err != nil {
 		panic(err)
 	} else {
 		fmt.Print("encoded frame:\n", hex.Dump(encodedFrame.Bytes()))
-		if decodedFrame, err := codec.Decode(&encodedFrame); err != nil {
+		if decodedFrame, err := codec.DecodeFrame(&encodedFrame); err != nil {
 			panic(err)
 		} else {
 			if useJson {


### PR DESCRIPTION
Add `EncodeRaw`, `DecodeRaw` and `RawFrame` to enable use cases where the user needs to deserialize the header and body separately.