### PR TITLE
Add optional auth parameter to handshake

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -22,8 +22,5 @@ func (client *CqlClient) Connect() (*CqlConnection, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &CqlConnection{
-		conn:  c,
-		codec: client.codec,
-	}, nil
+	return NewCqlConnection(c, client.codec), nil
 }

--- a/client/connection.go
+++ b/client/connection.go
@@ -10,6 +10,13 @@ type CqlConnection struct {
 	codec frame.RawCodec
 }
 
+func NewCqlConnection(conn net.Conn, codec frame.RawCodec) *CqlConnection {
+	return &CqlConnection{
+		conn:  conn,
+		codec: codec,
+	}
+}
+
 func (c *CqlConnection) Send(f *frame.Frame) error {
 	return c.codec.EncodeFrame(f, c.conn)
 }


### PR DESCRIPTION
This PR adds an `optionalAuth` parameter to the handshake method so that it supports cases where the cluster itself doesn't enforce authentication.

Added new tests for this use case.