### PR TITLE
Add support for request handlers server-side

### DIFF
--- a/client/handshake_test.go
+++ b/client/handshake_test.go
@@ -1,0 +1,69 @@
+package client_test
+
+import (
+	"context"
+	"github.com/datastax/go-cassandra-native-protocol/client"
+	"github.com/datastax/go-cassandra-native-protocol/primitive"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestHandshakeHandler_NoAuth(t *testing.T) {
+
+	server := client.NewCqlServer("127.0.0.1:9043", nil)
+	server.RequestHandlers = []client.RequestHandler{client.HandshakeHandler}
+
+	clt := client.NewCqlClient("127.0.0.1:9043", nil)
+
+	ctx, cancelFn := context.WithCancel(context.Background())
+
+	err := server.Start(ctx)
+	require.Nil(t, err)
+
+	clientConn, err := clt.Connect(ctx)
+	require.Nil(t, err)
+	require.NotNil(t, clientConn)
+
+	err = clientConn.InitiateHandshake(primitive.ProtocolVersion4, client.ManagedStreamId)
+	require.Nil(t, err)
+
+	cancelFn()
+
+	assert.Eventually(t, clientConn.IsClosed, time.Second*10, time.Millisecond*10)
+	assert.Eventually(t, server.IsClosed, time.Second*10, time.Millisecond*10)
+
+}
+
+func TestHandshakeHandler_Auth(t *testing.T) {
+
+	server := client.NewCqlServer("127.0.0.1:9043", &client.AuthCredentials{
+		Username: "user1",
+		Password: "pass1",
+	})
+	server.RequestHandlers = []client.RequestHandler{client.HandshakeHandler}
+
+	clt := client.NewCqlClient("127.0.0.1:9043", &client.AuthCredentials{
+		Username: "user1",
+		Password: "pass1",
+	})
+
+	ctx, cancelFn := context.WithCancel(context.Background())
+
+	err := server.Start(ctx)
+	require.Nil(t, err)
+
+	clientConn, err := clt.Connect(ctx)
+	require.Nil(t, err)
+	require.NotNil(t, clientConn)
+
+	err = clientConn.InitiateHandshake(primitive.ProtocolVersion4, client.ManagedStreamId)
+	require.Nil(t, err)
+
+	cancelFn()
+
+	assert.Eventually(t, clientConn.IsClosed, time.Second*10, time.Millisecond*10)
+	assert.Eventually(t, server.IsClosed, time.Second*10, time.Millisecond*10)
+
+}

--- a/client/heartbeat.go
+++ b/client/heartbeat.go
@@ -1,0 +1,17 @@
+package client
+
+import (
+	"github.com/datastax/go-cassandra-native-protocol/frame"
+	"github.com/datastax/go-cassandra-native-protocol/message"
+	"github.com/rs/zerolog/log"
+)
+
+// A RequestHandler to handle server-side heartbeats. This handler assumes that every OPTIONS request is a heartbeat
+// probe and replies with a SUPPORTED response.
+func HeartbeatHandler(request *frame.Frame, conn *CqlServerConnection, _ RequestHandlerContext) (response *frame.Frame) {
+	if _, ok := request.Body.Message.(*message.Options); ok {
+		log.Debug().Msgf("%v: [heartbeat handler]: received heartbeat probe", conn)
+		response, _ = frame.NewResponseFrame(request.Header.Version, request.Header.StreamId, nil, nil, nil, &message.Supported{}, false)
+	}
+	return
+}

--- a/client/heartbeat_test.go
+++ b/client/heartbeat_test.go
@@ -1,0 +1,53 @@
+package client_test
+
+import (
+	"context"
+	"github.com/datastax/go-cassandra-native-protocol/client"
+	"github.com/datastax/go-cassandra-native-protocol/frame"
+	"github.com/datastax/go-cassandra-native-protocol/message"
+	"github.com/datastax/go-cassandra-native-protocol/primitive"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestHeartbeatHandler(t *testing.T) {
+
+	server := client.NewCqlServer("127.0.0.1:9043", nil)
+	server.RequestHandlers = []client.RequestHandler{client.HeartbeatHandler}
+
+	clt := client.NewCqlClient("127.0.0.1:9043", nil)
+
+	ctx, cancelFn := context.WithCancel(context.Background())
+
+	err := server.Start(ctx)
+	require.Nil(t, err)
+
+	clientConn, err := clt.Connect(ctx)
+	require.Nil(t, err)
+	require.NotNil(t, clientConn)
+
+	heartbeat, _ := frame.NewRequestFrame(
+		primitive.ProtocolVersion4,
+		client.ManagedStreamId,
+		false,
+		nil,
+		&message.Options{},
+		false,
+	)
+
+	for i := 0; i < 100; i++ {
+		response, err := clientConn.SendAndReceive(heartbeat)
+		require.NotNil(t, response)
+		require.Nil(t, err)
+		require.Equal(t, primitive.OpCodeSupported, response.Header.OpCode)
+		require.IsType(t, &message.Supported{}, response.Body.Message)
+	}
+
+	cancelFn()
+
+	assert.Eventually(t, clientConn.IsClosed, time.Second*10, time.Millisecond*10)
+	assert.Eventually(t, server.IsClosed, time.Second*10, time.Millisecond*10)
+
+}

--- a/client/server.go
+++ b/client/server.go
@@ -28,6 +28,19 @@ const (
 	ServerStateClosed     = int32(iota)
 )
 
+// The RequestHandler invocation context. Each invocation of a given RequestHandler will be passed
+// one instance of a RequestHandlerContext, that remains the same between invocations. This allows
+// handlers to become stateful if required.
+type RequestHandlerContext map[string]interface{}
+
+// A request handler is a callback function that gets invoked whenever a CqlServerConnection receives an incoming
+// frame. The handler function should inspect the request frame and determine if it can handle the response for it.
+// If so, it should return a non-nil response frame. When that happens, no further handlers will be tried for the
+// incoming request.
+// If a handler returns nil, it is assumed that it was not able to handle the request, in which case another handler,
+// if any, may be tried.
+type RequestHandler func(request *frame.Frame, conn *CqlServerConnection, ctx RequestHandlerContext) (response *frame.Frame)
+
 // CqlServer is a minimalistic server stub that can be used to mimic CQL-compatible backends. It is preferable to
 // create CqlServer instances using the constructor function NewCqlServer. Once the server is properly created and
 // configured, use Start to start the server, then call Accept or AcceptAny to accept incoming client connections.
@@ -48,6 +61,8 @@ type CqlServer struct {
 	AcceptTimeout time.Duration
 	// The timeout to apply for closing idle connections.
 	IdleTimeout time.Duration
+	// An optional list of handlers to handle incoming requests.
+	RequestHandlers []RequestHandler
 
 	ctx                context.Context
 	cancel             context.CancelFunc
@@ -162,6 +177,7 @@ func (server *CqlServer) acceptLoop() {
 					server.Codec,
 					server.MaxInFlight,
 					server.IdleTimeout,
+					server.RequestHandlers,
 					server.connectionsHandler.onConnectionClosed,
 				); err != nil {
 					log.Error().Msgf("%v: failed to create incoming client connection: %v", server, connection)
@@ -277,9 +293,11 @@ func (server *CqlServer) BindAndInit(
 // CqlServerConnection instances should be created by calling CqlServer.Accept or CqlServer.Bind.
 type CqlServerConnection struct {
 	conn        net.Conn
+	credentials *AuthCredentials
 	codec       frame.Codec
 	idleTimeout time.Duration
-	credentials *AuthCredentials
+	handlers    []RequestHandler
+	handlerCtx  []RequestHandlerContext
 	incoming    chan *frame.Frame
 	outgoing    chan *frame.Frame
 	waitGroup   *sync.WaitGroup
@@ -296,6 +314,7 @@ func newCqlServerConnection(
 	codec frame.Codec,
 	maxInFlight int,
 	idleTimeout time.Duration,
+	handlers []RequestHandler,
 	onClose func(*CqlServerConnection),
 ) (*CqlServerConnection, error) {
 	if conn == nil {
@@ -314,10 +333,15 @@ func newCqlServerConnection(
 		codec:       codec,
 		credentials: credentials,
 		idleTimeout: idleTimeout,
+		handlers:    handlers,
+		handlerCtx:  make([]RequestHandlerContext, len(handlers)),
 		incoming:    make(chan *frame.Frame, maxInFlight),
 		outgoing:    make(chan *frame.Frame, maxInFlight),
 		waitGroup:   &sync.WaitGroup{},
 		onClose:     onClose,
+	}
+	for i := range handlers {
+		connection.handlerCtx[i] = RequestHandlerContext{}
 	}
 	connection.ctx, connection.cancel = context.WithCancel(ctx)
 	connection.incomingLoop()
@@ -378,6 +402,9 @@ func (c *CqlServerConnection) incomingLoop() {
 				default:
 					log.Error().Msgf("%v: incoming frames queue is full, discarding frame: %v", c, incoming)
 				}
+				if len(c.handlers) > 0 {
+					c.invokeRequestHandlers(incoming)
+				}
 			}
 		}
 		c.waitGroup.Done()
@@ -430,6 +457,28 @@ func (c *CqlServerConnection) awaitDone() {
 		log.Debug().Err(c.ctx.Err()).Msgf("%v: context was closed", c)
 		c.waitGroup.Done()
 		c.abort()
+	}()
+}
+
+func (c *CqlServerConnection) invokeRequestHandlers(request *frame.Frame) {
+	c.waitGroup.Add(1)
+	go func() {
+		log.Debug().Msgf("%v: invoking request handlers for incoming request: %v", c, request)
+		var response *frame.Frame
+		var err error
+		for i, handler := range c.handlers {
+			if response = handler(request, c, c.handlerCtx[i]); response != nil {
+				log.Debug().Msgf("%v: request handler %v produced response: %v", c, i, response)
+				if err = c.Send(response); err != nil {
+					log.Error().Err(err).Msgf("%v: send failed for frame: %v", c, response)
+				}
+				break
+			}
+		}
+		if response == nil {
+			log.Debug().Msgf("%v: no request handler could handle the request: %v", c, request)
+		}
+		c.waitGroup.Done()
 	}()
 }
 

--- a/client/server_test.go
+++ b/client/server_test.go
@@ -114,6 +114,14 @@ func TestCqlServer_AllAcceptedClients(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, clientConn2)
 
+	serverConn1, err := server.Accept(clientConn1)
+	require.Nil(t, err)
+	require.NotNil(t, serverConn1)
+
+	serverConn2, err := server.Accept(clientConn2)
+	require.Nil(t, err)
+	require.NotNil(t, serverConn2)
+
 	clients, err := server.AllAcceptedClients()
 	require.Nil(t, err)
 	require.NotNil(t, clients)


### PR DESCRIPTION
This PR introduces the notion of `RequestHandler` for `CqlServer` objects. Request handlers make it possible to inject behavior to be executed automatically when a request frame is received, thus allowing tests to program the server's behavior, pretty much like Simulacron.