### PR TITLE
Switch from type aliases to real types for primitive protocol types

### DIFF
--- a/datatype/datatype.go
+++ b/datatype/datatype.go
@@ -25,7 +25,7 @@ type codec interface {
 }
 
 func WriteDataType(t DataType, dest io.Writer, version primitive.ProtocolVersion) (err error) {
-	if err = primitive.WriteShort(t.GetDataTypeCode(), dest); err != nil {
+	if err = primitive.WriteShort(uint16(t.GetDataTypeCode()), dest); err != nil {
 		return fmt.Errorf("cannot write data type code %v: %w", t.GetDataTypeCode(), err)
 	} else if codec, err := findCodec(t.GetDataTypeCode()); err != nil {
 		return err
@@ -48,10 +48,10 @@ func LengthOfDataType(t DataType, version primitive.ProtocolVersion) (length int
 }
 
 func ReadDataType(source io.Reader, version primitive.ProtocolVersion) (decoded DataType, err error) {
-	var typeCode primitive.DataTypeCode
+	var typeCode uint16
 	if typeCode, err = primitive.ReadShort(source); err != nil {
 		return nil, fmt.Errorf("cannot read data type code: %w", err)
-	} else if codec, err := findCodec(typeCode); err != nil {
+	} else if codec, err := findCodec(primitive.DataTypeCode(typeCode)); err != nil {
 		return nil, err
 	} else if decoded, err = codec.decode(source, version); err != nil {
 		return nil, fmt.Errorf("cannot read data type code %v: %w", typeCode, err)

--- a/datatype/primitive.go
+++ b/datatype/primitive.go
@@ -101,7 +101,7 @@ func (c *primitiveTypeCodec) encode(t DataType, _ io.Writer, version primitive.P
 	if !ok {
 		return errors.New(fmt.Sprintf("expected PrimitiveType, got %T", t))
 	}
-	if err := primitive.CheckPrimitiveDataTypeCode(t.GetDataTypeCode()); err != nil {
+	if err := primitive.CheckValidDataTypeCode(t.GetDataTypeCode()); err != nil {
 		return err
 	}
 	if version < primitive.ProtocolVersion5 && c.primitiveType.GetDataTypeCode() == primitive.DataTypeCodeDuration {
@@ -115,7 +115,7 @@ func (c *primitiveTypeCodec) encodedLength(t DataType, _ primitive.ProtocolVersi
 	if !ok {
 		return -1, errors.New(fmt.Sprintf("expected PrimitiveType, got %T", t))
 	}
-	if err := primitive.CheckPrimitiveDataTypeCode(t.GetDataTypeCode()); err != nil {
+	if err := primitive.CheckValidDataTypeCode(t.GetDataTypeCode()); err != nil {
 		return -1, err
 	}
 	return 0, nil

--- a/frame/frame.go
+++ b/frame/frame.go
@@ -57,18 +57,18 @@ func NewRequestFrame(
 	if message.IsResponse() {
 		return nil, fmt.Errorf("message is not a request: opcode %d", message.GetOpCode())
 	}
-	var flags primitive.HeaderFlag = 0
+	var flags primitive.HeaderFlag
 	if tracing {
-		flags |= primitive.HeaderFlagTracing
+		flags = flags.Add(primitive.HeaderFlagTracing)
 	}
 	if customPayload != nil {
-		flags |= primitive.HeaderFlagCustomPayload
+		flags = flags.Add(primitive.HeaderFlagCustomPayload)
 	}
-	if primitive.IsProtocolVersionBeta(version) {
-		flags |= primitive.HeaderFlagUseBeta
+	if version.IsBeta() {
+		flags = flags.Add(primitive.HeaderFlagUseBeta)
 	}
 	if compress && isCompressible(message.GetOpCode()) {
-		flags |= primitive.HeaderFlagCompressed
+		flags = flags.Add(primitive.HeaderFlagCompressed)
 	}
 	return &Frame{
 		Header: &Header{
@@ -100,19 +100,19 @@ func NewResponseFrame(
 	}
 	var flags primitive.HeaderFlag = 0
 	if tracingId != nil {
-		flags |= primitive.HeaderFlagTracing
+		flags = flags.Add(primitive.HeaderFlagTracing)
 	}
 	if customPayload != nil {
-		flags |= primitive.HeaderFlagCustomPayload
+		flags = flags.Add(primitive.HeaderFlagCustomPayload)
 	}
 	if warnings != nil {
-		flags |= primitive.HeaderFlagWarning
+		flags = flags.Add(primitive.HeaderFlagWarning)
 	}
-	if primitive.IsProtocolVersionBeta(version) {
-		flags |= primitive.HeaderFlagUseBeta
+	if version.IsBeta() {
+		flags = flags.Add(primitive.HeaderFlagUseBeta)
 	}
 	if compress && isCompressible(message.GetOpCode()) {
-		flags |= primitive.HeaderFlagCompressed
+		flags = flags.Add(primitive.HeaderFlagCompressed)
 	}
 	return &Frame{
 		Header: &Header{

--- a/message/batch_test.go
+++ b/message/batch_test.go
@@ -25,12 +25,12 @@ func TestBatchCodec_Encode(t *testing.T) {
 					"invalid batch type",
 					&Batch{Type: primitive.BatchType(42)},
 					nil,
-					errors.New("invalid BATCH type: 42"),
+					errors.New("invalid BATCH type: BatchType ? [0X2A]"),
 				},
 				{
 					"empty batch",
 					&Batch{},
-					[]byte{primitive.BatchTypeLogged},
+					[]byte{byte(primitive.BatchTypeLogged)},
 					errors.New("BATCH messages must contain at least one child query"),
 				},
 				{
@@ -48,7 +48,7 @@ func TestBatchCodec_Encode(t *testing.T) {
 						},
 					},
 					[]byte{
-						primitive.BatchTypeLogged,
+						byte(primitive.BatchTypeLogged),
 						0, 2, // children count
 						0,                            // child 1 kind
 						0, 0, 0, 6, I, N, S, E, R, T, // child 1 query
@@ -78,7 +78,7 @@ func TestBatchCodec_Encode(t *testing.T) {
 						DefaultTimestamp:  &primitive.NillableInt64{Value: 123},
 					},
 					[]byte{
-						primitive.BatchTypeUnlogged,
+						byte(primitive.BatchTypeUnlogged),
 						0, 1, // children count
 						0,                            // child 1 kind
 						0, 0, 0, 6, I, N, S, E, R, T, // child 1 query
@@ -116,12 +116,12 @@ func TestBatchCodec_Encode(t *testing.T) {
 					"invalid batch type",
 					&Batch{Type: primitive.BatchType(42)},
 					nil,
-					errors.New("invalid BATCH type: 42"),
+					errors.New("invalid BATCH type: BatchType ? [0X2A]"),
 				},
 				{
 					"empty batch",
 					&Batch{},
-					[]byte{primitive.BatchTypeLogged},
+					[]byte{byte(primitive.BatchTypeLogged)},
 					errors.New("BATCH messages must contain at least one child query"),
 				},
 				{
@@ -139,7 +139,7 @@ func TestBatchCodec_Encode(t *testing.T) {
 						},
 					},
 					[]byte{
-						primitive.BatchTypeLogged,
+						byte(primitive.BatchTypeLogged),
 						0, 2, // children count
 						0,                            // child 1 kind
 						0, 0, 0, 6, I, N, S, E, R, T, // child 1 query
@@ -169,7 +169,7 @@ func TestBatchCodec_Encode(t *testing.T) {
 						DefaultTimestamp:  &primitive.NillableInt64{Value: 123},
 					},
 					[]byte{
-						primitive.BatchTypeUnlogged,
+						byte(primitive.BatchTypeUnlogged),
 						0, 1, // children count
 						0,                            // child 1 kind
 						0, 0, 0, 6, I, N, S, E, R, T, // child 1 query
@@ -207,12 +207,12 @@ func TestBatchCodec_Encode(t *testing.T) {
 					"invalid batch type",
 					&Batch{Type: primitive.BatchType(42)},
 					nil,
-					errors.New("invalid BATCH type: 42"),
+					errors.New("invalid BATCH type: BatchType ? [0X2A]"),
 				},
 				{
 					"empty batch",
 					&Batch{},
-					[]byte{primitive.BatchTypeLogged},
+					[]byte{byte(primitive.BatchTypeLogged)},
 					errors.New("BATCH messages must contain at least one child query"),
 				},
 				{
@@ -230,7 +230,7 @@ func TestBatchCodec_Encode(t *testing.T) {
 						},
 					},
 					[]byte{
-						primitive.BatchTypeLogged,
+						byte(primitive.BatchTypeLogged),
 						0, 2, // children count
 						0,                            // child 1 kind
 						0, 0, 0, 6, I, N, S, E, R, T, // child 1 query
@@ -261,7 +261,7 @@ func TestBatchCodec_Encode(t *testing.T) {
 						Keyspace:          "ks1",
 					},
 					[]byte{
-						primitive.BatchTypeUnlogged,
+						byte(primitive.BatchTypeUnlogged),
 						0, 1, // children count
 						0,                            // child 1 kind
 						0, 0, 0, 6, I, N, S, E, R, T, // child 1 query
@@ -563,12 +563,12 @@ func TestBatchCodec_Decode(t *testing.T) {
 						0, // flags
 					},
 					nil,
-					errors.New("invalid BATCH type: 42"),
+					errors.New("invalid BATCH type: BatchType ? [0X2A]"),
 				},
 				{
 					"empty batch",
 					[]byte{
-						primitive.BatchTypeLogged,
+						byte(primitive.BatchTypeLogged),
 						0, 0, // children count
 						0, 0, // consistency level
 						0, // flags
@@ -579,7 +579,7 @@ func TestBatchCodec_Decode(t *testing.T) {
 				{
 					"batch with 2 children",
 					[]byte{
-						primitive.BatchTypeLogged,
+						byte(primitive.BatchTypeLogged),
 						0, 2, // children count
 						0,                            // child 1 kind
 						0, 0, 0, 6, I, N, S, E, R, T, // child 1 query
@@ -609,7 +609,7 @@ func TestBatchCodec_Decode(t *testing.T) {
 				{
 					"batch with custom options",
 					[]byte{
-						primitive.BatchTypeUnlogged,
+						byte(primitive.BatchTypeUnlogged),
 						0, 1, // children count
 						0,                            // child 1 kind
 						0, 0, 0, 6, I, N, S, E, R, T, // child 1 query
@@ -658,12 +658,12 @@ func TestBatchCodec_Decode(t *testing.T) {
 						0, 0, 0, 0, // flags
 					},
 					nil,
-					errors.New("invalid BATCH type: 42"),
+					errors.New("invalid BATCH type: BatchType ? [0X2A]"),
 				},
 				{
 					"empty batch",
 					[]byte{
-						primitive.BatchTypeLogged,
+						byte(primitive.BatchTypeLogged),
 						0, 0, // children count
 						0, 0, // consistency level
 						0, 0, 0, 0, // flags
@@ -674,7 +674,7 @@ func TestBatchCodec_Decode(t *testing.T) {
 				{
 					"batch with 2 children",
 					[]byte{
-						primitive.BatchTypeLogged,
+						byte(primitive.BatchTypeLogged),
 						0, 2, // children count
 						0,                            // child 1 kind
 						0, 0, 0, 6, I, N, S, E, R, T, // child 1 query
@@ -704,7 +704,7 @@ func TestBatchCodec_Decode(t *testing.T) {
 				{
 					"batch with custom options",
 					[]byte{
-						primitive.BatchTypeUnlogged,
+						byte(primitive.BatchTypeUnlogged),
 						0, 1, // children count
 						0,                            // child 1 kind
 						0, 0, 0, 6, I, N, S, E, R, T, // child 1 query
@@ -753,12 +753,12 @@ func TestBatchCodec_Decode(t *testing.T) {
 						0, 0, 0, 0, // flags
 					},
 					nil,
-					errors.New("invalid BATCH type: 42"),
+					errors.New("invalid BATCH type: BatchType ? [0X2A]"),
 				},
 				{
 					"empty batch",
 					[]byte{
-						primitive.BatchTypeLogged,
+						byte(primitive.BatchTypeLogged),
 						0, 0, // children count
 						0, 0, // consistency level
 						0, 0, 0, 0, // flags
@@ -769,7 +769,7 @@ func TestBatchCodec_Decode(t *testing.T) {
 				{
 					"batch with 2 children",
 					[]byte{
-						primitive.BatchTypeLogged,
+						byte(primitive.BatchTypeLogged),
 						0, 2, // children count
 						0,                            // child 1 kind
 						0, 0, 0, 6, I, N, S, E, R, T, // child 1 query
@@ -799,7 +799,7 @@ func TestBatchCodec_Decode(t *testing.T) {
 				{
 					"batch with custom options",
 					[]byte{
-						primitive.BatchTypeUnlogged,
+						byte(primitive.BatchTypeUnlogged),
 						0, 1, // children count
 						0,                            // child 1 kind
 						0, 0, 0, 6, I, N, S, E, R, T, // child 1 query

--- a/message/dse_continuous_paging_options.go
+++ b/message/dse_continuous_paging_options.go
@@ -22,7 +22,7 @@ type ContinuousPagingOptions struct {
 }
 
 func EncodeContinuousPagingOptions(options *ContinuousPagingOptions, dest io.Writer, version primitive.ProtocolVersion) (err error) {
-	if err = primitive.CheckDseProtocolVersion(version); err != nil {
+	if err = primitive.CheckValidDseProtocolVersion(version); err != nil {
 		return err
 	} else if err = primitive.WriteInt(options.MaxPages, dest); err != nil {
 		return fmt.Errorf("cannot write max num pages: %w", err)
@@ -37,7 +37,7 @@ func EncodeContinuousPagingOptions(options *ContinuousPagingOptions, dest io.Wri
 }
 
 func LengthOfContinuousPagingOptions(_ *ContinuousPagingOptions, version primitive.ProtocolVersion) (length int, err error) {
-	if err = primitive.CheckDseProtocolVersion(version); err != nil {
+	if err = primitive.CheckValidDseProtocolVersion(version); err != nil {
 		return -1, err
 	}
 	length += primitive.LengthOfInt // max num pages
@@ -49,7 +49,7 @@ func LengthOfContinuousPagingOptions(_ *ContinuousPagingOptions, version primiti
 }
 
 func DecodeContinuousPagingOptions(source io.Reader, version primitive.ProtocolVersion) (options *ContinuousPagingOptions, err error) {
-	if err = primitive.CheckDseProtocolVersion(version); err != nil {
+	if err = primitive.CheckValidDseProtocolVersion(version); err != nil {
 		return nil, err
 	}
 	options = &ContinuousPagingOptions{}

--- a/message/error.go
+++ b/message/error.go
@@ -606,7 +606,7 @@ func (c *errorCodec) Encode(msg Message, dest io.Writer, version primitive.Proto
 	if !ok {
 		return fmt.Errorf("expected Error, got %T", msg)
 	}
-	if err = primitive.WriteInt(errMsg.GetErrorCode(), dest); err != nil {
+	if err = primitive.WriteInt(int32(errMsg.GetErrorCode()), dest); err != nil {
 		return fmt.Errorf("cannot write ERROR code: %w", err)
 	}
 	if err = primitive.WriteString(errMsg.GetErrorMessage(), dest); err != nil {
@@ -629,7 +629,7 @@ func (c *errorCodec) Encode(msg Message, dest io.Writer, version primitive.Proto
 		if !ok {
 			return fmt.Errorf("expected *message.Unavailable, got %T", msg)
 		}
-		if err = primitive.WriteShort(unavailable.Consistency, dest); err != nil {
+		if err = primitive.WriteShort(uint16(unavailable.Consistency), dest); err != nil {
 			return fmt.Errorf("cannot write ERROR UNAVAILABLE consistency: %w", err)
 		} else if err = primitive.WriteInt(unavailable.Required, dest); err != nil {
 			return fmt.Errorf("cannot write ERROR UNAVAILABLE required: %w", err)
@@ -642,7 +642,7 @@ func (c *errorCodec) Encode(msg Message, dest io.Writer, version primitive.Proto
 		if !ok {
 			return fmt.Errorf("expected *message.ReadTimeout, got %T", msg)
 		}
-		if err = primitive.WriteShort(readTimeout.Consistency, dest); err != nil {
+		if err = primitive.WriteShort(uint16(readTimeout.Consistency), dest); err != nil {
 			return fmt.Errorf("cannot write ERROR READ TIMEOUT consistency: %w", err)
 		} else if err = primitive.WriteInt(readTimeout.Received, dest); err != nil {
 			return fmt.Errorf("cannot write ERROR READ TIMEOUT received: %w", err)
@@ -663,13 +663,13 @@ func (c *errorCodec) Encode(msg Message, dest io.Writer, version primitive.Proto
 		if !ok {
 			return fmt.Errorf("expected *message.WriteTimeout, got %T", msg)
 		}
-		if err = primitive.WriteShort(writeTimeout.Consistency, dest); err != nil {
+		if err = primitive.WriteShort(uint16(writeTimeout.Consistency), dest); err != nil {
 			return fmt.Errorf("cannot write ERROR WRITE TIMEOUT consistency: %w", err)
 		} else if err = primitive.WriteInt(writeTimeout.Received, dest); err != nil {
 			return fmt.Errorf("cannot write ERROR WRITE TIMEOUT received: %w", err)
 		} else if err = primitive.WriteInt(writeTimeout.BlockFor, dest); err != nil {
 			return fmt.Errorf("cannot write ERROR WRITE TIMEOUT block for: %w", err)
-		} else if err = primitive.WriteString(writeTimeout.WriteType, dest); err != nil {
+		} else if err = primitive.WriteString(string(writeTimeout.WriteType), dest); err != nil {
 			return fmt.Errorf("cannot write ERROR WRITE TIMEOUT write type: %w", err)
 		}
 
@@ -678,7 +678,7 @@ func (c *errorCodec) Encode(msg Message, dest io.Writer, version primitive.Proto
 		if !ok {
 			return fmt.Errorf("expected *message.ReadFailure, got %T", msg)
 		}
-		if err = primitive.WriteShort(readFailure.Consistency, dest); err != nil {
+		if err = primitive.WriteShort(uint16(readFailure.Consistency), dest); err != nil {
 			return fmt.Errorf("cannot write ERROR READ FAILURE consistency: %w", err)
 		} else if err = primitive.WriteInt(readFailure.Received, dest); err != nil {
 			return fmt.Errorf("cannot write ERROR READ FAILURE received: %w", err)
@@ -708,7 +708,7 @@ func (c *errorCodec) Encode(msg Message, dest io.Writer, version primitive.Proto
 		if !ok {
 			return fmt.Errorf("expected *message.WriteFailure, got %T", msg)
 		}
-		if err = primitive.WriteShort(writeFailure.Consistency, dest); err != nil {
+		if err = primitive.WriteShort(uint16(writeFailure.Consistency), dest); err != nil {
 			return fmt.Errorf("cannot write ERROR WRITE FAILURE consistency: %w", err)
 		} else if err = primitive.WriteInt(writeFailure.Received, dest); err != nil {
 			return fmt.Errorf("cannot write ERROR WRITE FAILURE received: %w", err)
@@ -724,7 +724,7 @@ func (c *errorCodec) Encode(msg Message, dest io.Writer, version primitive.Proto
 				return fmt.Errorf("cannot write ERROR WRITE FAILURE num failures: %w", err)
 			}
 		}
-		if err = primitive.WriteString(writeFailure.WriteType, dest); err != nil {
+		if err = primitive.WriteString(string(writeFailure.WriteType), dest); err != nil {
 			return fmt.Errorf("cannot write ERROR WRITE FAILURE write type: %w", err)
 		}
 
@@ -799,10 +799,10 @@ func (c *errorCodec) EncodedLength(msg Message, version primitive.ProtocolVersio
 		if !ok {
 			return -1, fmt.Errorf("expected *message.WriteTimeout, got %T", msg)
 		}
-		length += primitive.LengthOfShort                          // consistency
-		length += primitive.LengthOfInt                            // received
-		length += primitive.LengthOfInt                            // block for
-		length += primitive.LengthOfString(writeTimeout.WriteType) // write type
+		length += primitive.LengthOfShort                                  // consistency
+		length += primitive.LengthOfInt                                    // received
+		length += primitive.LengthOfInt                                    // block for
+		length += primitive.LengthOfString(string(writeTimeout.WriteType)) // write type
 
 	case primitive.ErrorCodeReadFailure:
 		length += primitive.LengthOfShort // consistency
@@ -828,10 +828,10 @@ func (c *errorCodec) EncodedLength(msg Message, version primitive.ProtocolVersio
 		if !ok {
 			return -1, fmt.Errorf("expected *message.WriteFailure, got %T", msg)
 		}
-		length += primitive.LengthOfShort                          // consistency
-		length += primitive.LengthOfInt                            // received
-		length += primitive.LengthOfInt                            // block for
-		length += primitive.LengthOfString(writeFailure.WriteType) // write type
+		length += primitive.LengthOfShort                                  // consistency
+		length += primitive.LengthOfInt                                    // received
+		length += primitive.LengthOfInt                                    // block for
+		length += primitive.LengthOfString(string(writeFailure.WriteType)) // write type
 		if version >= primitive.ProtocolVersion5 {
 			if reasonMapLength, err := primitive.LengthOfReasonMap(writeFailure.FailureReasons); err != nil {
 				return -1, fmt.Errorf("cannot compute length of ERROR WRITE FAILURE rason map: %w", err)
@@ -865,7 +865,7 @@ func (c *errorCodec) EncodedLength(msg Message, version primitive.ProtocolVersio
 }
 
 func (c *errorCodec) Decode(source io.Reader, version primitive.ProtocolVersion) (msg Message, err error) {
-	var code primitive.ErrorCode
+	var code int32
 	if code, err = primitive.ReadInt(source); err != nil {
 		return nil, fmt.Errorf("cannot read ERROR code: %w", err)
 	}
@@ -873,7 +873,7 @@ func (c *errorCodec) Decode(source io.Reader, version primitive.ProtocolVersion)
 	if errorMsg, err = primitive.ReadString(source); err != nil {
 		return nil, fmt.Errorf("cannot read ERROR message: %w", err)
 	}
-	switch code {
+	switch primitive.ErrorCode(code) {
 	case primitive.ErrorCodeServerError:
 		return &ServerError{errorMsg}, nil
 	case primitive.ErrorCodeProtocolError:
@@ -897,9 +897,11 @@ func (c *errorCodec) Decode(source io.Reader, version primitive.ProtocolVersion)
 
 	case primitive.ErrorCodeUnavailable:
 		var msg = &Unavailable{ErrorMessage: errorMsg}
-		if msg.Consistency, err = primitive.ReadShort(source); err != nil {
+		var consistency uint16
+		if consistency, err = primitive.ReadShort(source); err != nil {
 			return nil, fmt.Errorf("cannot read ERROR UNAVAILABLE consistency: %w", err)
 		}
+		msg.Consistency = primitive.ConsistencyLevel(consistency)
 		if msg.Required, err = primitive.ReadInt(source); err != nil {
 			return nil, fmt.Errorf("cannot read ERROR UNAVAILABLE required: %w", err)
 		}
@@ -910,9 +912,11 @@ func (c *errorCodec) Decode(source io.Reader, version primitive.ProtocolVersion)
 
 	case primitive.ErrorCodeReadTimeout:
 		var msg = &ReadTimeout{ErrorMessage: errorMsg}
-		if msg.Consistency, err = primitive.ReadShort(source); err != nil {
+		var consistency uint16
+		if consistency, err = primitive.ReadShort(source); err != nil {
 			return nil, fmt.Errorf("cannot read ERROR READ TIMEOUT consistency: %w", err)
 		}
+		msg.Consistency = primitive.ConsistencyLevel(consistency)
 		if msg.Received, err = primitive.ReadInt(source); err != nil {
 			return nil, fmt.Errorf("cannot read ERROR READ TIMEOUT received: %w", err)
 		}
@@ -932,25 +936,31 @@ func (c *errorCodec) Decode(source io.Reader, version primitive.ProtocolVersion)
 
 	case primitive.ErrorCodeWriteTimeout:
 		var msg = &WriteTimeout{ErrorMessage: errorMsg}
-		if msg.Consistency, err = primitive.ReadShort(source); err != nil {
+		var consistency uint16
+		if consistency, err = primitive.ReadShort(source); err != nil {
 			return nil, fmt.Errorf("cannot read ERROR WRITE TIMEOUT consistency: %w", err)
 		}
+		msg.Consistency = primitive.ConsistencyLevel(consistency)
 		if msg.Received, err = primitive.ReadInt(source); err != nil {
 			return nil, fmt.Errorf("cannot read ERROR WRITE TIMEOUT received: %w", err)
 		}
 		if msg.BlockFor, err = primitive.ReadInt(source); err != nil {
 			return nil, fmt.Errorf("cannot read ERROR WRITE TIMEOUT block for: %w", err)
 		}
-		if msg.WriteType, err = primitive.ReadString(source); err != nil {
+		var writeType string
+		if writeType, err = primitive.ReadString(source); err != nil {
 			return nil, fmt.Errorf("cannot read ERROR WRITE TIMEOUT write type: %w", err)
 		}
+		msg.WriteType = primitive.WriteType(writeType)
 		return msg, nil
 
 	case primitive.ErrorCodeReadFailure:
 		var msg = &ReadFailure{ErrorMessage: errorMsg}
-		if msg.Consistency, err = primitive.ReadShort(source); err != nil {
+		var consistency uint16
+		if consistency, err = primitive.ReadShort(source); err != nil {
 			return nil, fmt.Errorf("cannot read ERROR READ FAILURE consistency: %w", err)
 		}
+		msg.Consistency = primitive.ConsistencyLevel(consistency)
 		if msg.Received, err = primitive.ReadInt(source); err != nil {
 			return nil, fmt.Errorf("cannot read ERROR READ FAILURE received: %w", err)
 		}
@@ -979,9 +989,11 @@ func (c *errorCodec) Decode(source io.Reader, version primitive.ProtocolVersion)
 
 	case primitive.ErrorCodeWriteFailure:
 		var msg = &WriteFailure{ErrorMessage: errorMsg}
-		if msg.Consistency, err = primitive.ReadShort(source); err != nil {
+		var consistency uint16
+		if consistency, err = primitive.ReadShort(source); err != nil {
 			return nil, fmt.Errorf("cannot read ERROR WRITE FAILURE consistency: %w", err)
 		}
+		msg.Consistency = primitive.ConsistencyLevel(consistency)
 		if msg.Received, err = primitive.ReadInt(source); err != nil {
 			return nil, fmt.Errorf("cannot read ERROR WRITE FAILURE received: %w", err)
 		}
@@ -997,10 +1009,12 @@ func (c *errorCodec) Decode(source io.Reader, version primitive.ProtocolVersion)
 				return nil, fmt.Errorf("cannot read ERROR WRITE FAILURE num failures: %w", err)
 			}
 		}
-		if msg.WriteType, err = primitive.ReadString(source); err != nil {
+		var writeType string
+		if writeType, err = primitive.ReadString(source); err != nil {
 			return nil, fmt.Errorf("cannot read ERROR WRITE FAILURE write type: %w", err)
 		}
-		if err = primitive.CheckWriteType(msg.WriteType); err != nil {
+		msg.WriteType = primitive.WriteType(writeType)
+		if err = primitive.CheckValidWriteType(msg.WriteType); err != nil {
 			return nil, err
 		}
 		return msg, nil

--- a/message/error_test.go
+++ b/message/error_test.go
@@ -408,7 +408,7 @@ func TestErrorCodec_EncodedLength(test *testing.T) {
 						primitive.LengthOfShort + // consistency
 						primitive.LengthOfInt + // received
 						primitive.LengthOfInt + // block for
-						primitive.LengthOfString(primitive.WriteTypeBatchLog), // write type
+						primitive.LengthOfString(string(primitive.WriteTypeBatchLog)), // write type
 					nil,
 				},
 				{
@@ -489,7 +489,7 @@ func TestErrorCodec_EncodedLength(test *testing.T) {
 						primitive.LengthOfInt + // received
 						primitive.LengthOfInt + // block for
 						primitive.LengthOfInt + // num failures
-						primitive.LengthOfString(primitive.WriteTypeBatchLog), // write type
+						primitive.LengthOfString(string(primitive.WriteTypeBatchLog)), // write type
 					nil,
 				},
 			}
@@ -547,7 +547,7 @@ func TestErrorCodec_EncodedLength(test *testing.T) {
 						primitive.LengthOfInt + // map length
 						primitive.LengthOfByte + net.IPv4len + // map key length
 						primitive.LengthOfShort + // map value length (reason code)
-						primitive.LengthOfString(primitive.WriteTypeBatchLog), // write type
+						primitive.LengthOfString(string(primitive.WriteTypeBatchLog)), // write type
 					nil,
 				},
 			}

--- a/message/event_test.go
+++ b/message/event_test.go
@@ -297,9 +297,9 @@ func TestEventCodec_EncodedLength(test *testing.T) {
 						Target:     primitive.SchemaChangeTargetKeyspace,
 						Keyspace:   "ks1",
 					},
-					primitive.LengthOfString(primitive.EventTypeSchemaChange) +
-						primitive.LengthOfString(primitive.SchemaChangeTypeCreated) +
-						primitive.LengthOfString(primitive.SchemaChangeTargetKeyspace) +
+					primitive.LengthOfString(string(primitive.EventTypeSchemaChange)) +
+						primitive.LengthOfString(string(primitive.SchemaChangeTypeCreated)) +
+						primitive.LengthOfString(string(primitive.SchemaChangeTargetKeyspace)) +
 						primitive.LengthOfString("ks1"),
 					nil,
 				},
@@ -311,9 +311,9 @@ func TestEventCodec_EncodedLength(test *testing.T) {
 						Keyspace:   "ks1",
 						Object:     "table1",
 					},
-					primitive.LengthOfString(primitive.EventTypeSchemaChange) +
-						primitive.LengthOfString(primitive.SchemaChangeTypeCreated) +
-						primitive.LengthOfString(primitive.SchemaChangeTargetTable) +
+					primitive.LengthOfString(string(primitive.EventTypeSchemaChange)) +
+						primitive.LengthOfString(string(primitive.SchemaChangeTypeCreated)) +
+						primitive.LengthOfString(string(primitive.SchemaChangeTargetTable)) +
 						primitive.LengthOfString("ks1") +
 						primitive.LengthOfString("table1"),
 					nil,
@@ -326,9 +326,9 @@ func TestEventCodec_EncodedLength(test *testing.T) {
 						Keyspace:   "ks1",
 						Object:     "udt1",
 					},
-					primitive.LengthOfString(primitive.EventTypeSchemaChange) +
-						primitive.LengthOfString(primitive.SchemaChangeTypeCreated) +
-						primitive.LengthOfString(primitive.SchemaChangeTargetType) +
+					primitive.LengthOfString(string(primitive.EventTypeSchemaChange)) +
+						primitive.LengthOfString(string(primitive.SchemaChangeTypeCreated)) +
+						primitive.LengthOfString(string(primitive.SchemaChangeTargetType)) +
 						primitive.LengthOfString("ks1") +
 						primitive.LengthOfString("udt1"),
 					nil,
@@ -342,9 +342,9 @@ func TestEventCodec_EncodedLength(test *testing.T) {
 						Object:     "func1",
 						Arguments:  []string{"int", "varchar"},
 					},
-					primitive.LengthOfString(primitive.EventTypeSchemaChange) +
-						primitive.LengthOfString(primitive.SchemaChangeTypeCreated) +
-						primitive.LengthOfString(primitive.SchemaChangeTargetFunction) +
+					primitive.LengthOfString(string(primitive.EventTypeSchemaChange)) +
+						primitive.LengthOfString(string(primitive.SchemaChangeTypeCreated)) +
+						primitive.LengthOfString(string(primitive.SchemaChangeTargetFunction)) +
 						primitive.LengthOfString("ks1") +
 						primitive.LengthOfString("func1") +
 						primitive.LengthOfStringList([]string{"int", "varchar"}),
@@ -359,9 +359,9 @@ func TestEventCodec_EncodedLength(test *testing.T) {
 						Object:     "agg1",
 						Arguments:  []string{"int", "varchar"},
 					},
-					primitive.LengthOfString(primitive.EventTypeSchemaChange) +
-						primitive.LengthOfString(primitive.SchemaChangeTypeCreated) +
-						primitive.LengthOfString(primitive.SchemaChangeTargetAggregate) +
+					primitive.LengthOfString(string(primitive.EventTypeSchemaChange)) +
+						primitive.LengthOfString(string(primitive.SchemaChangeTypeCreated)) +
+						primitive.LengthOfString(string(primitive.SchemaChangeTargetAggregate)) +
 						primitive.LengthOfString("ks1") +
 						primitive.LengthOfString("agg1") +
 						primitive.LengthOfStringList([]string{"int", "varchar"}),
@@ -376,8 +376,8 @@ func TestEventCodec_EncodedLength(test *testing.T) {
 							Port: 9042,
 						},
 					},
-					primitive.LengthOfString(primitive.EventTypeStatusChange) +
-						primitive.LengthOfString(primitive.StatusChangeTypeUp) +
+					primitive.LengthOfString(string(primitive.EventTypeStatusChange)) +
+						primitive.LengthOfString(string(primitive.StatusChangeTypeUp)) +
 						primitive.LengthOfByte + net.IPv4len +
 						primitive.LengthOfInt,
 					nil,
@@ -391,8 +391,8 @@ func TestEventCodec_EncodedLength(test *testing.T) {
 							Port: 9042,
 						},
 					},
-					primitive.LengthOfString(primitive.EventTypeTopologyChange) +
-						primitive.LengthOfString(primitive.TopologyChangeTypeNewNode) +
+					primitive.LengthOfString(string(primitive.EventTypeTopologyChange)) +
+						primitive.LengthOfString(string(primitive.TopologyChangeTypeNewNode)) +
 						primitive.LengthOfByte + net.IPv4len +
 						primitive.LengthOfInt,
 					nil,

--- a/message/prepare.go
+++ b/message/prepare.go
@@ -28,7 +28,7 @@ func (m *Prepare) String() string {
 func (m *Prepare) Flags() primitive.PrepareFlag {
 	var flags primitive.PrepareFlag
 	if m.Keyspace != "" {
-		flags |= primitive.PrepareFlagWithKeyspace
+		flags = flags.Add(primitive.PrepareFlagWithKeyspace)
 	}
 	return flags
 }
@@ -50,7 +50,7 @@ func (c *prepareCodec) Encode(msg Message, dest io.Writer, version primitive.Pro
 		if err = primitive.WriteInt(int32(flags), dest); err != nil {
 			return fmt.Errorf("cannot write PREPARE flags: %w", err)
 		}
-		if flags&primitive.PrepareFlagWithKeyspace > 0 {
+		if flags.Contains(primitive.PrepareFlagWithKeyspace) {
 			if prepare.Keyspace == "" {
 				return errors.New("cannot write empty keyspace")
 			} else if err = primitive.WriteString(prepare.Keyspace, dest); err != nil {
@@ -88,7 +88,7 @@ func (c *prepareCodec) Decode(source io.Reader, version primitive.ProtocolVersio
 			return nil, fmt.Errorf("cannot read PREPARE flags: %w", err)
 		}
 		flags = primitive.PrepareFlag(f)
-		if flags&primitive.PrepareFlagWithKeyspace > 0 {
+		if flags.Contains(primitive.PrepareFlagWithKeyspace) {
 			if prepare.Keyspace, err = primitive.ReadString(source); err != nil {
 				return nil, fmt.Errorf("cannot read PREPARE keyspace: %w", err)
 			}

--- a/message/query_options.go
+++ b/message/query_options.go
@@ -42,38 +42,38 @@ func (o *QueryOptions) String() string {
 func (o *QueryOptions) Flags() primitive.QueryFlag {
 	var flags primitive.QueryFlag
 	if o.PositionalValues != nil {
-		flags |= primitive.QueryFlagValues
+		flags = flags.Add(primitive.QueryFlagValues)
 	}
 	if o.NamedValues != nil {
-		flags |= primitive.QueryFlagValues
-		flags |= primitive.QueryFlagValueNames
+		flags = flags.Add(primitive.QueryFlagValues)
+		flags = flags.Add(primitive.QueryFlagValueNames)
 	}
 	if o.SkipMetadata {
-		flags |= primitive.QueryFlagSkipMetadata
+		flags = flags.Add(primitive.QueryFlagSkipMetadata)
 	}
 	if o.PageSize > 0 {
-		flags |= primitive.QueryFlagPageSize
+		flags = flags.Add(primitive.QueryFlagPageSize)
 		if o.PageSizeInBytes {
-			flags |= primitive.QueryFlagDsePageSizeBytes
+			flags = flags.Add(primitive.QueryFlagDsePageSizeBytes)
 		}
 	}
 	if o.PagingState != nil {
-		flags |= primitive.QueryFlagPagingState
+		flags = flags.Add(primitive.QueryFlagPagingState)
 	}
 	if o.SerialConsistency != nil {
-		flags |= primitive.QueryFlagSerialConsistency
+		flags = flags.Add(primitive.QueryFlagSerialConsistency)
 	}
 	if o.DefaultTimestamp != nil {
-		flags |= primitive.QueryFlagDefaultTimestamp
+		flags = flags.Add(primitive.QueryFlagDefaultTimestamp)
 	}
 	if o.Keyspace != "" {
-		flags |= primitive.QueryFlagWithKeyspace
+		flags = flags.Add(primitive.QueryFlagWithKeyspace)
 	}
 	if o.NowInSeconds != nil {
-		flags |= primitive.QueryFlagNowInSeconds
+		flags = flags.Add(primitive.QueryFlagNowInSeconds)
 	}
 	if o.ContinuousPagingOptions != nil {
-		flags |= primitive.QueryFlagDseWithContinuousPagingOptions
+		flags = flags.Add(primitive.QueryFlagDseWithContinuousPagingOptions)
 	}
 	return flags
 }
@@ -82,9 +82,9 @@ func EncodeQueryOptions(options *QueryOptions, dest io.Writer, version primitive
 	if options == nil {
 		options = &QueryOptions{} // use defaults if nil provided
 	}
-	if err := primitive.CheckNonSerialConsistencyLevel(options.Consistency); err != nil {
+	if err := primitive.CheckValidNonSerialConsistencyLevel(options.Consistency); err != nil {
 		return err
-	} else if err = primitive.WriteShort(options.Consistency, dest); err != nil {
+	} else if err = primitive.WriteShort(uint16(options.Consistency), dest); err != nil {
 		return fmt.Errorf("cannot write consistency: %w", err)
 	}
 	flags := options.Flags()
@@ -97,8 +97,8 @@ func EncodeQueryOptions(options *QueryOptions, dest io.Writer, version primitive
 			return fmt.Errorf("cannot write flags: %w", err)
 		}
 	}
-	if flags&primitive.QueryFlagValues != 0 {
-		if flags&primitive.QueryFlagValueNames != 0 {
+	if flags.Contains(primitive.QueryFlagValues) {
+		if flags.Contains(primitive.QueryFlagValueNames) {
 			if err = primitive.WriteNamedValues(options.NamedValues, dest, version); err != nil {
 				return fmt.Errorf("cannot write named [value]s: %w", err)
 			}
@@ -108,41 +108,41 @@ func EncodeQueryOptions(options *QueryOptions, dest io.Writer, version primitive
 			}
 		}
 	}
-	if flags&primitive.QueryFlagPageSize != 0 {
+	if flags.Contains(primitive.QueryFlagPageSize) {
 		if err = primitive.WriteInt(options.PageSize, dest); err != nil {
 			return fmt.Errorf("cannot write page size: %w", err)
 		}
 	}
-	if flags&primitive.QueryFlagPagingState != 0 {
+	if flags.Contains(primitive.QueryFlagPagingState) {
 		if err = primitive.WriteBytes(options.PagingState, dest); err != nil {
 			return fmt.Errorf("cannot write paging state: %w", err)
 		}
 	}
-	if flags&primitive.QueryFlagSerialConsistency != 0 {
-		if err := primitive.CheckSerialConsistencyLevel(options.SerialConsistency.Value); err != nil {
+	if flags.Contains(primitive.QueryFlagSerialConsistency) {
+		if err := primitive.CheckValidSerialConsistencyLevel(options.SerialConsistency.Value); err != nil {
 			return err
-		} else if err = primitive.WriteShort(options.SerialConsistency.Value, dest); err != nil {
+		} else if err = primitive.WriteShort(uint16(options.SerialConsistency.Value), dest); err != nil {
 			return fmt.Errorf("cannot write serial consistency: %w", err)
 		}
 	}
-	if flags&primitive.QueryFlagDefaultTimestamp != 0 {
+	if flags.Contains(primitive.QueryFlagDefaultTimestamp) {
 		if err = primitive.WriteLong(options.DefaultTimestamp.Value, dest); err != nil {
 			return fmt.Errorf("cannot write default timestamp: %w", err)
 		}
 	}
-	if flags&primitive.QueryFlagWithKeyspace != 0 {
+	if flags.Contains(primitive.QueryFlagWithKeyspace) {
 		if options.Keyspace == "" {
 			return errors.New("cannot write empty keyspace")
 		} else if err = primitive.WriteString(options.Keyspace, dest); err != nil {
 			return fmt.Errorf("cannot write keyspace: %w", err)
 		}
 	}
-	if flags&primitive.QueryFlagNowInSeconds != 0 {
+	if flags.Contains(primitive.QueryFlagNowInSeconds) {
 		if err = primitive.WriteInt(options.NowInSeconds.Value, dest); err != nil {
 			return fmt.Errorf("cannot write now-in-seconds: %w", err)
 		}
 	}
-	if flags&primitive.QueryFlagDseWithContinuousPagingOptions != 0 {
+	if flags.Contains(primitive.QueryFlagDseWithContinuousPagingOptions) {
 		if err = EncodeContinuousPagingOptions(options.ContinuousPagingOptions, dest, version); err != nil {
 			return fmt.Errorf("cannot encode continuous paging options: %w", err)
 		}
@@ -162,8 +162,8 @@ func LengthOfQueryOptions(options *QueryOptions, version primitive.ProtocolVersi
 	}
 	var s int
 	flags := options.Flags()
-	if flags&primitive.QueryFlagValues != 0 {
-		if flags&primitive.QueryFlagValueNames != 0 {
+	if flags.Contains(primitive.QueryFlagValues) {
+		if flags.Contains(primitive.QueryFlagValueNames) {
 			s, err = primitive.LengthOfNamedValues(options.NamedValues)
 		} else {
 			s, err = primitive.LengthOfPositionalValues(options.PositionalValues)
@@ -173,25 +173,25 @@ func LengthOfQueryOptions(options *QueryOptions, version primitive.ProtocolVersi
 		return -1, fmt.Errorf("cannot compute length of query options values: %w", err)
 	}
 	length += s
-	if flags&primitive.QueryFlagPageSize != 0 {
+	if flags.Contains(primitive.QueryFlagPageSize) {
 		length += primitive.LengthOfInt
 	}
-	if flags&primitive.QueryFlagPagingState != 0 {
+	if flags.Contains(primitive.QueryFlagPagingState) {
 		length += primitive.LengthOfBytes(options.PagingState)
 	}
-	if flags&primitive.QueryFlagSerialConsistency != 0 {
+	if flags.Contains(primitive.QueryFlagSerialConsistency) {
 		length += primitive.LengthOfShort
 	}
-	if flags&primitive.QueryFlagDefaultTimestamp != 0 {
+	if flags.Contains(primitive.QueryFlagDefaultTimestamp) {
 		length += primitive.LengthOfLong
 	}
-	if flags&primitive.QueryFlagWithKeyspace != 0 {
+	if flags.Contains(primitive.QueryFlagWithKeyspace) {
 		length += primitive.LengthOfString(options.Keyspace)
 	}
-	if flags&primitive.QueryFlagNowInSeconds != 0 {
+	if flags.Contains(primitive.QueryFlagNowInSeconds) {
 		length += primitive.LengthOfInt
 	}
-	if flags&primitive.QueryFlagDseWithContinuousPagingOptions != 0 {
+	if flags.Contains(primitive.QueryFlagDseWithContinuousPagingOptions) {
 		if lengthOfContinuousPagingOptions, err := LengthOfContinuousPagingOptions(options.ContinuousPagingOptions, version); err != nil {
 			return -1, fmt.Errorf("cannot compute length of continuous paging options: %w", err)
 		} else {
@@ -203,9 +203,12 @@ func LengthOfQueryOptions(options *QueryOptions, version primitive.ProtocolVersi
 
 func DecodeQueryOptions(source io.Reader, version primitive.ProtocolVersion) (options *QueryOptions, err error) {
 	options = &QueryOptions{}
-	if options.Consistency, err = primitive.ReadShort(source); err != nil {
+	var consistency uint16
+	if consistency, err = primitive.ReadShort(source); err != nil {
 		return nil, fmt.Errorf("cannot read consistency: %w", err)
-	} else if err = primitive.CheckConsistencyLevel(options.Consistency); err != nil {
+	}
+	options.Consistency = primitive.ConsistencyLevel(consistency)
+	if err = primitive.CheckValidConsistencyLevel(options.Consistency); err != nil {
 		return nil, err
 	}
 	var flags primitive.QueryFlag
@@ -221,8 +224,8 @@ func DecodeQueryOptions(source io.Reader, version primitive.ProtocolVersion) (op
 	if err != nil {
 		return nil, fmt.Errorf("cannot read flags: %w", err)
 	}
-	if flags&primitive.QueryFlagValues != 0 {
-		if flags&primitive.QueryFlagValueNames != 0 {
+	if flags.Contains(primitive.QueryFlagValues) {
+		if flags.Contains(primitive.QueryFlagValueNames) {
 			options.NamedValues, err = primitive.ReadNamedValues(source, version)
 		} else {
 			options.PositionalValues, err = primitive.ReadPositionalValues(source, version)
@@ -231,46 +234,49 @@ func DecodeQueryOptions(source io.Reader, version primitive.ProtocolVersion) (op
 	if err != nil {
 		return nil, fmt.Errorf("cannot read [value]s: %w", err)
 	}
-	options.SkipMetadata = flags&primitive.QueryFlagSkipMetadata != 0
-	if flags&primitive.QueryFlagPageSize != 0 {
+	options.SkipMetadata = flags.Contains(primitive.QueryFlagSkipMetadata)
+	if flags.Contains(primitive.QueryFlagPageSize) {
 		if options.PageSize, err = primitive.ReadInt(source); err != nil {
 			return nil, fmt.Errorf("cannot read page size: %w", err)
 		}
-		if flags&primitive.QueryFlagDsePageSizeBytes != 0 {
+		if flags.Contains(primitive.QueryFlagDsePageSizeBytes) {
 			options.PageSizeInBytes = true
 		}
 	}
-	if flags&primitive.QueryFlagPagingState != 0 {
+	if flags.Contains(primitive.QueryFlagPagingState) {
 		if options.PagingState, err = primitive.ReadBytes(source); err != nil {
 			return nil, fmt.Errorf("cannot read paging state: %w", err)
 		}
 	}
-	if flags&primitive.QueryFlagSerialConsistency != 0 {
+	if flags.Contains(primitive.QueryFlagSerialConsistency) {
 		options.SerialConsistency = &primitive.NillableConsistencyLevel{}
-		if options.SerialConsistency.Value, err = primitive.ReadShort(source); err != nil {
+		var serialConsistency uint16
+		if serialConsistency, err = primitive.ReadShort(source); err != nil {
 			return nil, fmt.Errorf("cannot read serial consistency: %w", err)
-		} else if err = primitive.CheckConsistencyLevel(options.SerialConsistency.Value); err != nil {
+		}
+		options.SerialConsistency.Value = primitive.ConsistencyLevel(serialConsistency)
+		if err = primitive.CheckValidConsistencyLevel(options.SerialConsistency.Value); err != nil {
 			return nil, err
 		}
 	}
-	if flags&primitive.QueryFlagDefaultTimestamp != 0 {
+	if flags.Contains(primitive.QueryFlagDefaultTimestamp) {
 		options.DefaultTimestamp = &primitive.NillableInt64{}
 		if options.DefaultTimestamp.Value, err = primitive.ReadLong(source); err != nil {
 			return nil, fmt.Errorf("cannot read default timestamp: %w", err)
 		}
 	}
-	if flags&primitive.QueryFlagWithKeyspace != 0 {
+	if flags.Contains(primitive.QueryFlagWithKeyspace) {
 		if options.Keyspace, err = primitive.ReadString(source); err != nil {
 			return nil, fmt.Errorf("cannot read keyspace: %w", err)
 		}
 	}
-	if flags&primitive.QueryFlagNowInSeconds != 0 {
+	if flags.Contains(primitive.QueryFlagNowInSeconds) {
 		options.NowInSeconds = &primitive.NillableInt32{}
 		if options.NowInSeconds.Value, err = primitive.ReadInt(source); err != nil {
 			return nil, fmt.Errorf("cannot read now-in-seconds: %w", err)
 		}
 	}
-	if flags&primitive.QueryFlagDseWithContinuousPagingOptions != 0 {
+	if flags.Contains(primitive.QueryFlagDseWithContinuousPagingOptions) {
 		if options.ContinuousPagingOptions, err = DecodeContinuousPagingOptions(source, version); err != nil {
 			return nil, fmt.Errorf("cannot read continuous paging options: %w", err)
 		}

--- a/message/result_schema_change_test.go
+++ b/message/result_schema_change_test.go
@@ -229,8 +229,8 @@ func TestResultCodec_EncodedLength_SchemaChange(test *testing.T) {
 						Keyspace:   "ks1",
 					},
 					primitive.LengthOfInt +
-						primitive.LengthOfString(primitive.SchemaChangeTypeCreated) +
-						primitive.LengthOfString(primitive.SchemaChangeTargetKeyspace) +
+						primitive.LengthOfString(string(primitive.SchemaChangeTypeCreated)) +
+						primitive.LengthOfString(string(primitive.SchemaChangeTargetKeyspace)) +
 						primitive.LengthOfString("ks1"),
 					nil,
 				},
@@ -243,8 +243,8 @@ func TestResultCodec_EncodedLength_SchemaChange(test *testing.T) {
 						Object:     "table1",
 					},
 					primitive.LengthOfInt +
-						primitive.LengthOfString(primitive.SchemaChangeTypeCreated) +
-						primitive.LengthOfString(primitive.SchemaChangeTargetTable) +
+						primitive.LengthOfString(string(primitive.SchemaChangeTypeCreated)) +
+						primitive.LengthOfString(string(primitive.SchemaChangeTargetTable)) +
 						primitive.LengthOfString("ks1") +
 						primitive.LengthOfString("table1"),
 					nil,
@@ -258,8 +258,8 @@ func TestResultCodec_EncodedLength_SchemaChange(test *testing.T) {
 						Object:     "udt1",
 					},
 					primitive.LengthOfInt +
-						primitive.LengthOfString(primitive.SchemaChangeTypeCreated) +
-						primitive.LengthOfString(primitive.SchemaChangeTargetType) +
+						primitive.LengthOfString(string(primitive.SchemaChangeTypeCreated)) +
+						primitive.LengthOfString(string(primitive.SchemaChangeTargetType)) +
 						primitive.LengthOfString("ks1") +
 						primitive.LengthOfString("udt1"),
 					nil,
@@ -274,8 +274,8 @@ func TestResultCodec_EncodedLength_SchemaChange(test *testing.T) {
 						Arguments:  []string{"int", "varchar"},
 					},
 					primitive.LengthOfInt +
-						primitive.LengthOfString(primitive.SchemaChangeTypeCreated) +
-						primitive.LengthOfString(primitive.SchemaChangeTargetFunction) +
+						primitive.LengthOfString(string(primitive.SchemaChangeTypeCreated)) +
+						primitive.LengthOfString(string(primitive.SchemaChangeTargetFunction)) +
 						primitive.LengthOfString("ks1") +
 						primitive.LengthOfString("func1") +
 						primitive.LengthOfStringList([]string{"int", "varchar"}),
@@ -291,8 +291,8 @@ func TestResultCodec_EncodedLength_SchemaChange(test *testing.T) {
 						Arguments:  []string{"int", "varchar"},
 					},
 					primitive.LengthOfInt +
-						primitive.LengthOfString(primitive.SchemaChangeTypeCreated) +
-						primitive.LengthOfString(primitive.SchemaChangeTargetAggregate) +
+						primitive.LengthOfString(string(primitive.SchemaChangeTypeCreated)) +
+						primitive.LengthOfString(string(primitive.SchemaChangeTargetAggregate)) +
 						primitive.LengthOfString("ks1") +
 						primitive.LengthOfString("agg1") +
 						primitive.LengthOfStringList([]string{"int", "varchar"}),

--- a/primitive/constants.go
+++ b/primitive/constants.go
@@ -1,6 +1,8 @@
 package primitive
 
-type ProtocolVersion = uint8
+import "fmt"
+
+type ProtocolVersion uint8
 
 const (
 
@@ -15,7 +17,53 @@ const (
 	ProtocolVersionDse2 = ProtocolVersion(0b_1_000010) // 2 + DSE bit = 66
 )
 
-type OpCode = uint8
+func (v ProtocolVersion) IsOss() bool {
+	switch v {
+	case ProtocolVersion3:
+	case ProtocolVersion4:
+	case ProtocolVersion5:
+	default:
+		return false
+	}
+	return true
+}
+
+func (v ProtocolVersion) IsDse() bool {
+	switch v {
+	case ProtocolVersionDse1:
+	case ProtocolVersionDse2:
+	default:
+		return false
+	}
+	return true
+}
+
+func (v ProtocolVersion) IsBeta() bool {
+	switch v {
+	case ProtocolVersion5:
+	default:
+		return false
+	}
+	return true
+}
+
+func (v ProtocolVersion) String() string {
+	switch v {
+	case ProtocolVersion3:
+		return "ProtocolVersion OSS 3"
+	case ProtocolVersion4:
+		return "ProtocolVersion OSS 4"
+	case ProtocolVersion5:
+		return "ProtocolVersion OSS 5 (beta)"
+	case ProtocolVersionDse1:
+		return "ProtocolVersion DSE 1"
+	case ProtocolVersionDse2:
+		return "ProtocolVersion DSE 2"
+	}
+	return fmt.Sprintf("ProtocolVersion ? [%#.2X]", v)
+}
+
+type OpCode uint8
 
 const (
 	// requests
@@ -39,41 +87,211 @@ const (
 	OpCodeAuthSuccess   = OpCode(0x10)
 )
 
-type ResultType = int32
+func (c OpCode) IsRequest() bool {
+	switch c {
+	case OpCodeStartup:
+	case OpCodeOptions:
+	case OpCodeQuery:
+	case OpCodePrepare:
+	case OpCodeExecute:
+	case OpCodeRegister:
+	case OpCodeBatch:
+	case OpCodeAuthResponse:
+	case OpCodeDseRevise:
+	default:
+		return false
+	}
+	return true
+}
+
+func (c OpCode) IsDse() bool {
+	switch c {
+	case OpCodeDseRevise:
+	default:
+		return false
+	}
+	return true
+}
+
+func (c OpCode) String() string {
+	switch c {
+	case OpCodeStartup:
+		return "OpCode STARTUP [0x01]"
+	case OpCodeOptions:
+		return "OpCode OPTIONS [0x05]"
+	case OpCodeQuery:
+		return "OpCode QUERY [0x07]"
+	case OpCodePrepare:
+		return "OpCode PREPARE [0x09]"
+	case OpCodeExecute:
+		return "OpCode EXECUTE [0x0A]"
+	case OpCodeRegister:
+		return "OpCode REGISTER [0x0B]"
+	case OpCodeBatch:
+		return "OpCode BATCH [0x0D]"
+	case OpCodeAuthResponse:
+		return "OpCode AUTH RESPONSE [0x0F]"
+	case OpCodeDseRevise:
+		return "OpCode REVISE [0xFF]"
+	// responses
+	case OpCodeError:
+		return "OpCode ERROR [0x00]"
+	case OpCodeReady:
+		return "OpCode READY [0x02]"
+	case OpCodeAuthenticate:
+		return "OpCode AUTHENTICATE [0x03]"
+	case OpCodeSupported:
+		return "OpCode SUPPORTED [0x06]"
+	case OpCodeResult:
+		return "OpCode RESULT [0x08]"
+	case OpCodeEvent:
+		return "OpCode EVENT [0x0C]"
+	case OpCodeAuthChallenge:
+		return "OpCode AUTH CHALLENGE [0x0E]"
+	case OpCodeAuthSuccess:
+		return "OpCode AUTH SUCCESS [0x10]"
+	}
+	return fmt.Sprintf("OpCode ? [%#.2X]", uint8(c))
+}
+
+type ResultType uint32
 
 const (
-	ResultTypeVoid         = ResultType(0x0001)
-	ResultTypeRows         = ResultType(0x0002)
-	ResultTypeSetKeyspace  = ResultType(0x0003)
-	ResultTypePrepared     = ResultType(0x0004)
-	ResultTypeSchemaChange = ResultType(0x0005)
+	ResultTypeVoid         = ResultType(0x00000001)
+	ResultTypeRows         = ResultType(0x00000002)
+	ResultTypeSetKeyspace  = ResultType(0x00000003)
+	ResultTypePrepared     = ResultType(0x00000004)
+	ResultTypeSchemaChange = ResultType(0x00000005)
 )
 
-type ErrorCode = int32
+func (r ResultType) String() string {
+	switch r {
+	case ResultTypeVoid:
+		return "ResultType Void [0x00000001]"
+	case ResultTypeRows:
+		return "ResultType Rows [0x00000002]"
+	case ResultTypeSetKeyspace:
+		return "ResultType SetKeyspace [0x00000003]"
+	case ResultTypePrepared:
+		return "ResultType Prepared [0x00000004]"
+	case ResultTypeSchemaChange:
+		return "ResultType SchemaChange [0x00000005]"
+	}
+	return fmt.Sprintf("ResultType ? [%#.8X]", uint32(r))
+}
+
+type ErrorCode uint32
 
 const (
-	ErrorCodeServerError         = ErrorCode(0x0000)
-	ErrorCodeProtocolError       = ErrorCode(0x000A)
-	ErrorCodeAuthenticationError = ErrorCode(0x0100)
-	ErrorCodeUnavailable         = ErrorCode(0x1000)
-	ErrorCodeOverloaded          = ErrorCode(0x1001)
-	ErrorCodeIsBootstrapping     = ErrorCode(0x1002)
-	ErrorCodeTruncateError       = ErrorCode(0x1003)
-	ErrorCodeWriteTimeout        = ErrorCode(0x1100)
-	ErrorCodeReadTimeout         = ErrorCode(0x1200)
-	ErrorCodeReadFailure         = ErrorCode(0x1300)
-	ErrorCodeFunctionFailure     = ErrorCode(0x1400)
-	ErrorCodeWriteFailure        = ErrorCode(0x1500)
-	ErrorCodeSyntaxError         = ErrorCode(0x2000)
-	ErrorCodeUnauthorized        = ErrorCode(0x2100)
-	ErrorCodeInvalid             = ErrorCode(0x2200)
-	ErrorCodeConfigError         = ErrorCode(0x2300)
-	ErrorCodeAlreadyExists       = ErrorCode(0x2400)
-	ErrorCodeUnprepared          = ErrorCode(0x2500)
+	// 0xx: fatal errors
+	ErrorCodeServerError         = ErrorCode(0x00000000)
+	ErrorCodeProtocolError       = ErrorCode(0x0000000A)
+	ErrorCodeAuthenticationError = ErrorCode(0x00000100)
+	// 1xx: request execution
+	ErrorCodeUnavailable     = ErrorCode(0x00001000)
+	ErrorCodeOverloaded      = ErrorCode(0x00001001)
+	ErrorCodeIsBootstrapping = ErrorCode(0x00001002)
+	ErrorCodeTruncateError   = ErrorCode(0x00001003)
+	ErrorCodeWriteTimeout    = ErrorCode(0x00001100)
+	ErrorCodeReadTimeout     = ErrorCode(0x00001200)
+	ErrorCodeReadFailure     = ErrorCode(0x00001300)
+	ErrorCodeFunctionFailure = ErrorCode(0x00001400)
+	ErrorCodeWriteFailure    = ErrorCode(0x00001500)
+	// 2xx: query validation
+	ErrorCodeSyntaxError   = ErrorCode(0x00002000)
+	ErrorCodeUnauthorized  = ErrorCode(0x00002100)
+	ErrorCodeInvalid       = ErrorCode(0x00002200)
+	ErrorCodeConfigError   = ErrorCode(0x00002300)
+	ErrorCodeAlreadyExists = ErrorCode(0x00002400)
+	ErrorCodeUnprepared    = ErrorCode(0x00002500)
 )
+
+func (c ErrorCode) IsFatalError() bool {
+	switch c {
+	case ErrorCodeServerError:
+	case ErrorCodeProtocolError:
+	case ErrorCodeAuthenticationError:
+	default:
+		return false
+	}
+	return true
+}
+
+func (c ErrorCode) IsRequestExecutionError() bool {
+	switch c {
+	case ErrorCodeUnavailable:
+	case ErrorCodeOverloaded:
+	case ErrorCodeIsBootstrapping:
+	case ErrorCodeTruncateError:
+	case ErrorCodeWriteTimeout:
+	case ErrorCodeReadTimeout:
+	case ErrorCodeReadFailure:
+	case ErrorCodeFunctionFailure:
+	case ErrorCodeWriteFailure:
+	default:
+		return false
+	}
+	return true
+}
+
+func (c ErrorCode) IsQueryValidationError() bool {
+	switch c {
+	case ErrorCodeSyntaxError:
+	case ErrorCodeUnauthorized:
+	case ErrorCodeInvalid:
+	case ErrorCodeConfigError:
+	case ErrorCodeAlreadyExists:
+	case ErrorCodeUnprepared:
+	default:
+		return false
+	}
+	return true
+}
+
+func (c ErrorCode) String() string {
+	switch c {
+	case ErrorCodeServerError:
+		return "ErrorCode ServerError [0x00000000]"
+	case ErrorCodeProtocolError:
+		return "ErrorCode ProtocolError [0x0000000A]"
+	case ErrorCodeAuthenticationError:
+		return "ErrorCode AuthenticationError [0x00000100]"
+	case ErrorCodeUnavailable:
+		return "ErrorCode Unavailable [0x00001000]"
+	case ErrorCodeOverloaded:
+		return "ErrorCode Overloaded [0x00001001]"
+	case ErrorCodeIsBootstrapping:
+		return "ErrorCode IsBootstrapping [0x00001002]"
+	case ErrorCodeTruncateError:
+		return "ErrorCode TruncateError [0x00001003]"
+	case ErrorCodeWriteTimeout:
+		return "ErrorCode WriteTimeout [0x00001100]"
+	case ErrorCodeReadTimeout:
+		return "ErrorCode ReadTimeout [0x00001200]"
+	case ErrorCodeReadFailure:
+		return "ErrorCode ReadFailure [0x00001300]"
+	case ErrorCodeFunctionFailure:
+		return "ErrorCode FunctionFailure [0x00001400]"
+	case ErrorCodeWriteFailure:
+		return "ErrorCode WriteFailure [0x00001500]"
+	case ErrorCodeSyntaxError:
+		return "ErrorCode SyntaxError [0x00002000]"
+	case ErrorCodeUnauthorized:
+		return "ErrorCode Unauthorized [0x00002100]"
+	case ErrorCodeInvalid:
+		return "ErrorCode Invalid [0x00002200]"
+	case ErrorCodeConfigError:
+		return "ErrorCode ConfigError [0x00002300]"
+	case ErrorCodeAlreadyExists:
+		return "ErrorCode AlreadyExists [0x00002400]"
+	case ErrorCodeUnprepared:
+		return "ErrorCode Unprepared [0x00002500]"
+	}
+	return fmt.Sprintf("ErrorCode ? [%#.8X]", uint32(c))
+}
 
 // Corresponds to protocol section 3 [consistency]
-type ConsistencyLevel = uint16
+type ConsistencyLevel uint16
 
 const (
 	ConsistencyLevelAny         = ConsistencyLevel(0x0000)
@@ -89,7 +307,55 @@ const (
 	ConsistencyLevelLocalOne    = ConsistencyLevel(0x000A)
 )
 
-type WriteType = string
+func (c ConsistencyLevel) IsSerial() bool {
+	switch c {
+	case ConsistencyLevelSerial:
+	case ConsistencyLevelLocalSerial:
+	default:
+		return false
+	}
+	return true
+}
+
+func (c ConsistencyLevel) IsLocal() bool {
+	switch c {
+	case ConsistencyLevelLocalSerial:
+	case ConsistencyLevelLocalOne:
+	default:
+		return false
+	}
+	return true
+}
+
+func (c ConsistencyLevel) String() string {
+	switch c {
+	case ConsistencyLevelAny:
+		return "ConsistencyLevel ANY [0x0000]"
+	case ConsistencyLevelOne:
+		return "ConsistencyLevel ONE [0x0001]"
+	case ConsistencyLevelTwo:
+		return "ConsistencyLevel TWO [0x0002]"
+	case ConsistencyLevelThree:
+		return "ConsistencyLevel THREE [0x0003]"
+	case ConsistencyLevelQuorum:
+		return "ConsistencyLevel QUORUM [0x0004]"
+	case ConsistencyLevelAll:
+		return "ConsistencyLevel ALL [0x0005]"
+	case ConsistencyLevelLocalQuorum:
+		return "ConsistencyLevel LOCAL_QUORUM [0x0006]"
+	case ConsistencyLevelEachQuorum:
+		return "ConsistencyLevel EACH_QUORUM [0x0007]"
+	case ConsistencyLevelSerial:
+		return "ConsistencyLevel SERIAL [0x0008]"
+	case ConsistencyLevelLocalSerial:
+		return "ConsistencyLevel LOCAL_SERIAL [0x0009]"
+	case ConsistencyLevelLocalOne:
+		return "ConsistencyLevel LOCAL_ONE [0x000A]"
+	}
+	return fmt.Sprintf("ConsistencyLevel ? [%#.4X]", uint16(c))
+}
+
+type WriteType string
 
 const (
 	WriteTypeSimple        = WriteType("SIMPLE")
@@ -101,7 +367,7 @@ const (
 	WriteTypeCdc           = WriteType("CDC")
 )
 
-type DataTypeCode = uint16
+type DataTypeCode uint16
 
 const (
 	DataTypeCodeCustom    = DataTypeCode(0x0000)
@@ -132,7 +398,65 @@ const (
 	DataTypeCodeTuple     = DataTypeCode(0x0031)
 )
 
-type EventType = string
+func (c DataTypeCode) String() string {
+	switch c {
+	case DataTypeCodeCustom:
+		return "DataTypeCode Custom [0x0000]"
+	case DataTypeCodeAscii:
+		return "DataTypeCode Ascii [0x0001]"
+	case DataTypeCodeBigint:
+		return "DataTypeCode Bigint [0x0002]"
+	case DataTypeCodeBlob:
+		return "DataTypeCode Blob [0x0003]"
+	case DataTypeCodeBoolean:
+		return "DataTypeCode Boolean [0x0004]"
+	case DataTypeCodeCounter:
+		return "DataTypeCode Counter [0x0005]"
+	case DataTypeCodeDecimal:
+		return "DataTypeCode Decimal [0x0006]"
+	case DataTypeCodeDouble:
+		return "DataTypeCode Double [0x0007]"
+	case DataTypeCodeFloat:
+		return "DataTypeCode Float [0x0008]"
+	case DataTypeCodeInt:
+		return "DataTypeCode Int [0x0009]"
+	case DataTypeCodeTimestamp:
+		return "DataTypeCode Timestamp [0x000B]"
+	case DataTypeCodeUuid:
+		return "DataTypeCode Uuid [0x000C]"
+	case DataTypeCodeVarchar:
+		return "DataTypeCode Varchar [0x000D]"
+	case DataTypeCodeVarint:
+		return "DataTypeCode Varint [0x000E]"
+	case DataTypeCodeTimeuuid:
+		return "DataTypeCode Timeuuid [0x000F]"
+	case DataTypeCodeInet:
+		return "DataTypeCode Inet [0x0010]"
+	case DataTypeCodeDate:
+		return "DataTypeCode Date [0x0011]"
+	case DataTypeCodeTime:
+		return "DataTypeCode Time [0x0012]"
+	case DataTypeCodeSmallint:
+		return "DataTypeCode Smallint [0x0013]"
+	case DataTypeCodeTinyint:
+		return "DataTypeCode Tinyint [0x0014]"
+	case DataTypeCodeDuration:
+		return "DataTypeCode Duration [0x0015]"
+	case DataTypeCodeList:
+		return "DataTypeCode List [0x0020]"
+	case DataTypeCodeMap:
+		return "DataTypeCode Map [0x0021]"
+	case DataTypeCodeSet:
+		return "DataTypeCode Set [0x0022]"
+	case DataTypeCodeUdt:
+		return "DataTypeCode Udt [0x0030]"
+	case DataTypeCodeTuple:
+		return "DataTypeCode Tuple [0x0031]"
+	}
+	return fmt.Sprintf("DataType ? [%#.4X]", uint16(c))
+}
+
+type EventType string
 
 const (
 	EventTypeTopologyChange = EventType("TOPOLOGY_CHANGE")
@@ -140,7 +464,7 @@ const (
 	EventTypeSchemaChange   = EventType("SCHEMA_CHANGE")
 )
 
-type SchemaChangeType = string
+type SchemaChangeType string
 
 const (
 	SchemaChangeTypeCreated = SchemaChangeType("CREATED")
@@ -148,7 +472,7 @@ const (
 	SchemaChangeTypeDropped = SchemaChangeType("DROPPED")
 )
 
-type SchemaChangeTarget = string
+type SchemaChangeTarget string
 
 const (
 	SchemaChangeTargetKeyspace  = SchemaChangeTarget("KEYSPACE")
@@ -158,21 +482,21 @@ const (
 	SchemaChangeTargetAggregate = SchemaChangeTarget("AGGREGATE")
 )
 
-type TopologyChangeType = string
+type TopologyChangeType string
 
 const (
 	TopologyChangeTypeNewNode     = TopologyChangeType("NEW_NODE")
 	TopologyChangeTypeRemovedNode = TopologyChangeType("REMOVED_NODE")
 )
 
-type StatusChangeType = string
+type StatusChangeType string
 
 const (
 	StatusChangeTypeUp   = StatusChangeType("UP")
 	StatusChangeTypeDown = StatusChangeType("DOWN")
 )
 
-type BatchType = uint8
+type BatchType uint8
 
 const (
 	BatchTypeLogged   = BatchType(0x00)
@@ -180,14 +504,36 @@ const (
 	BatchTypeCounter  = BatchType(0x02)
 )
 
-type BatchChildStatementType = uint8
+func (t BatchType) String() string {
+	switch t {
+	case BatchTypeLogged:
+		return "BatchType LOGGED [0x00]"
+	case BatchTypeUnlogged:
+		return "BatchType UNLOGGED [0x01]"
+	case BatchTypeCounter:
+		return "BatchType COUNTER [0x02]"
+	}
+	return fmt.Sprintf("BatchType ? [%#.2X]", uint8(t))
+}
+
+type BatchChildType uint8
 
 const (
-	BatchChildTypeQueryString = BatchChildStatementType(0x00)
-	BatchChildTypePreparedId  = BatchChildStatementType(0x01)
+	BatchChildTypeQueryString = BatchChildType(0x00)
+	BatchChildTypePreparedId  = BatchChildType(0x01)
 )
 
-type HeaderFlag = uint8
+func (t BatchChildType) String() string {
+	switch t {
+	case BatchChildTypeQueryString:
+		return "BatchChildType QueryString [0x00]"
+	case BatchChildTypePreparedId:
+		return "BatchChildType PreparedId [0x01]"
+	}
+	return fmt.Sprintf("BatchChildType ? [%#.2X]", uint8(t))
+}
+
+type HeaderFlag uint8
 
 const (
 	HeaderFlagCompressed    = HeaderFlag(0x01)
@@ -197,8 +543,32 @@ const (
 	HeaderFlagUseBeta       = HeaderFlag(0x10)
 )
 
+func (f HeaderFlag) Add(other HeaderFlag) HeaderFlag {
+	return f | other
+}
+
+func (f HeaderFlag) Contains(other HeaderFlag) bool {
+	return f&other != 0
+}
+
+func (f HeaderFlag) String() string {
+	switch f {
+	case HeaderFlagCompressed:
+		return fmt.Sprintf("HeaderFlag Compressed [0x01 %#.8b]", f)
+	case HeaderFlagTracing:
+		return fmt.Sprintf("HeaderFlag Tracing [0x02 %#.8b]", f)
+	case HeaderFlagCustomPayload:
+		return fmt.Sprintf("HeaderFlag CustomPayload [0x04 %#.8b]", f)
+	case HeaderFlagWarning:
+		return fmt.Sprintf("HeaderFlag Warning [0x08 %#.8b]", f)
+	case HeaderFlagUseBeta:
+		return fmt.Sprintf("HeaderFlag UseBeta [0x10 %#.8b]", f)
+	}
+	return fmt.Sprintf("HeaderFlag ? [%#.2X %#.8b]", uint8(f), uint8(f))
+}
+
 // Note: QueryFlag was encoded as [byte] in v3 and v4, but changed to [int] in v5
-type QueryFlag = uint32
+type QueryFlag uint32
 
 const (
 	QueryFlagValues            = QueryFlag(0x00000001)
@@ -215,7 +585,43 @@ const (
 	QueryFlagDseWithContinuousPagingOptions = QueryFlag(0x80000000) // DSE v1+
 )
 
-type RowsFlag = uint32
+func (f QueryFlag) Add(other QueryFlag) QueryFlag {
+	return f | other
+}
+
+func (f QueryFlag) Contains(other QueryFlag) bool {
+	return f&other != 0
+}
+
+func (f QueryFlag) String() string {
+	switch f {
+	case QueryFlagValues:
+		return fmt.Sprintf("QueryFlag Values [0x00000001 %#.32b]", f)
+	case QueryFlagSkipMetadata:
+		return fmt.Sprintf("QueryFlag SkipMetadata [0x00000002 %#.32b]", f)
+	case QueryFlagPageSize:
+		return fmt.Sprintf("QueryFlag PageSize [0x00000004 %#.32b]", f)
+	case QueryFlagPagingState:
+		return fmt.Sprintf("QueryFlag PagingState [0x00000008 %#.32b]", f)
+	case QueryFlagSerialConsistency:
+		return fmt.Sprintf("QueryFlag SerialConsistency [0x00000010 %#.32b]", f)
+	case QueryFlagDefaultTimestamp:
+		return fmt.Sprintf("QueryFlag DefaultTimestamp [0x00000020 %#.32b]", f)
+	case QueryFlagValueNames:
+		return fmt.Sprintf("QueryFlag ValueNames [0x00000040 %#.32b]", f)
+	case QueryFlagWithKeyspace:
+		return fmt.Sprintf("QueryFlag WithKeyspace [0x00000080 %#.32b]", f)
+	case QueryFlagNowInSeconds:
+		return fmt.Sprintf("QueryFlag NowInSeconds [0x00000100 %#.32b]", f)
+	case QueryFlagDsePageSizeBytes:
+		return fmt.Sprintf("QueryFlag DsePageSizeBytes [0x40000000 %#.32b]", f)
+	case QueryFlagDseWithContinuousPagingOptions:
+		return fmt.Sprintf("QueryFlag DseWithContinuousPagingOptions [0x80000000 %#.32b]", f)
+	}
+	return fmt.Sprintf("QueryFlag ? [%#.8X %#.32b]", uint32(f), uint32(f))
+}
+
+type RowsFlag uint32
 
 const (
 	RowsFlagGlobalTablesSpec = RowsFlag(0x00000001)
@@ -227,26 +633,95 @@ const (
 	RowsFlagDseLastContinuousPage = RowsFlag(0x80000000) // DSE v1+
 )
 
-type VariablesFlag = uint32
+func (f RowsFlag) Add(other RowsFlag) RowsFlag {
+	return f | other
+}
+
+func (f RowsFlag) Contains(other RowsFlag) bool {
+	return f&other != 0
+}
+
+func (f RowsFlag) String() string {
+	switch f {
+	case RowsFlagGlobalTablesSpec:
+		return fmt.Sprintf("RowsFlag GlobalTablesSpec [0x00000001 %#.32b]", f)
+	case RowsFlagHasMorePages:
+		return fmt.Sprintf("RowsFlag HasMorePages [0x00000002 %#.32b]", f)
+	case RowsFlagNoMetadata:
+		return fmt.Sprintf("RowsFlag NoMetadata [0x00000004 %#.32b]", f)
+	case RowsFlagMetadataChanged:
+		return fmt.Sprintf("RowsFlag MetadataChanged [0x00000008 %#.32b]", f)
+	// DSE-specific flags
+	case RowsFlagDseContinuousPaging:
+		return fmt.Sprintf("RowsFlag ContinuousPaging [0x40000000 %#.32b]", f)
+	case RowsFlagDseLastContinuousPage:
+		return fmt.Sprintf("RowsFlag LastContinuousPage [0x80000000 %#.32b]", f)
+	}
+	return fmt.Sprintf("RowsFlag ? [%#.8X %#.32b]", uint32(f), uint32(f))
+}
+
+type VariablesFlag uint32
 
 const (
 	VariablesFlagGlobalTablesSpec = VariablesFlag(0x00000001)
 )
 
-type PrepareFlag = uint32
+func (f VariablesFlag) Add(other VariablesFlag) VariablesFlag {
+	return f | other
+}
+
+func (f VariablesFlag) Contains(other VariablesFlag) bool {
+	return f&other != 0
+}
+
+func (f VariablesFlag) String() string {
+	switch f {
+	case VariablesFlagGlobalTablesSpec:
+		return fmt.Sprintf("VariablesFlag GlobalTablesSpec [0x00000001 %#.32b]", f)
+	}
+	return fmt.Sprintf("VariablesFlag ? [%#.8X %#.32b]", uint32(f), uint32(f))
+}
+
+type PrepareFlag uint32
 
 const (
 	PrepareFlagWithKeyspace = PrepareFlag(0x00000001) // v5 and DSE v2
 )
 
-type DseRevisionType = int32
+func (f PrepareFlag) Add(other PrepareFlag) PrepareFlag {
+	return f | other
+}
+
+func (f PrepareFlag) Contains(other PrepareFlag) bool {
+	return f&other != 0
+}
+
+func (f PrepareFlag) String() string {
+	switch f {
+	case PrepareFlagWithKeyspace:
+		return fmt.Sprintf("PrepareFlag WithKeyspace [0x00000001 %#.32b]", f)
+	}
+	return fmt.Sprintf("PrepareFlag ? [%#.8X %#.32b]", uint32(f), uint32(f))
+}
+
+type DseRevisionType uint32
 
 const (
 	DseRevisionTypeCancelContinuousPaging = DseRevisionType(0x00000001)
 	DseRevisionTypeMoreContinuousPages    = DseRevisionType(0x00000002) // DSE v2+
 )
 
-type FailureCode = uint16
+func (t DseRevisionType) String() string {
+	switch t {
+	case DseRevisionTypeCancelContinuousPaging:
+		return "DseRevisionType CancelContinuousPaging [0x00000001]"
+	case DseRevisionTypeMoreContinuousPages:
+		return "DseRevisionType MoreContinuousPages [0x00000002]"
+	}
+	return fmt.Sprintf("DseRevisionType ? [%#.8X]", uint32(t))
+}
+
+type FailureCode uint16
 
 const (
 	FailureCodeUnknown               = FailureCode(0x0000)
@@ -257,3 +732,23 @@ const (
 	FailureCodeTableNotFound         = FailureCode(0x0005)
 	FailureCodeKeyspaceNotFound      = FailureCode(0x0006)
 )
+
+func (c FailureCode) String() string {
+	switch c {
+	case FailureCodeUnknown:
+		return "FailureCode Unknown [0x0000]"
+	case FailureCodeTooManyTombstonesRead:
+		return "FailureCode TooManyTombstonesRead [0x0001]"
+	case FailureCodeIndexNotAvailable:
+		return "FailureCode IndexNotAvailable [0x0002]"
+	case FailureCodeCdcSpaceFull:
+		return "FailureCode CdcSpaceFull [0x0003]"
+	case FailureCodeCounterWrite:
+		return "FailureCode CounterWrite [0x0004]"
+	case FailureCodeTableNotFound:
+		return "FailureCode TableNotFound [0x0005]"
+	case FailureCodeKeyspaceNotFound:
+		return "FailureCode KeyspaceNotFound [0x0006]"
+	}
+	return fmt.Sprintf("FailureCode ? [%#.4X]", uint16(c))
+}

--- a/primitive/reasonmap.go
+++ b/primitive/reasonmap.go
@@ -28,7 +28,7 @@ func ReadReasonMap(source io.Reader) ([]*FailureReason, error) {
 			} else if code, err := ReadShort(source); err != nil {
 				return nil, fmt.Errorf("cannot read reason map value for element %d: %w", i, err)
 			} else {
-				reasonMap[i] = &FailureReason{addr, code}
+				reasonMap[i] = &FailureReason{addr, FailureCode(code)}
 			}
 		}
 		return reasonMap, err
@@ -42,7 +42,7 @@ func WriteReasonMap(reasonMap []*FailureReason, dest io.Writer) error {
 	for i, reason := range reasonMap {
 		if err := WriteInetAddr(reason.Endpoint, dest); err != nil {
 			return fmt.Errorf("cannot write reason map key for element %d: %w", i, err)
-		} else if err = WriteShort(reason.Code, dest); err != nil {
+		} else if err = WriteShort(uint16(reason.Code), dest); err != nil {
 			return fmt.Errorf("cannot write reason map value for element %d: %w", i, err)
 		}
 	}

--- a/primitive/values.go
+++ b/primitive/values.go
@@ -45,7 +45,7 @@ func ReadValue(source io.Reader, version ProtocolVersion) (*Value, error) {
 		return NewNullValue(), nil
 	} else if length == ValueTypeUnset {
 		if version < ProtocolVersion4 {
-			return nil, fmt.Errorf("cannot use unset value in protocol version: %v", version)
+			return nil, fmt.Errorf("cannot use unset value with %v", version)
 		}
 		return NewUnsetValue(), nil
 	} else if length < 0 {
@@ -70,7 +70,7 @@ func WriteValue(value *Value, dest io.Writer, version ProtocolVersion) error {
 		return WriteInt(ValueTypeNull, dest)
 	case ValueTypeUnset:
 		if version < ProtocolVersion4 {
-			return fmt.Errorf("cannot use unset value in protocol version: %v", version)
+			return fmt.Errorf("cannot use unset value with %v", version)
 		}
 		return WriteInt(ValueTypeUnset, dest)
 	case ValueTypeRegular:

--- a/primitive/values_test.go
+++ b/primitive/values_test.go
@@ -32,7 +32,7 @@ func TestReadValue(t *testing.T) {
 						0xff, 0xff, 0xff, 0xfe, // length -2
 					},
 					nil,
-					fmt.Errorf("cannot use unset value in protocol version: 3"),
+					fmt.Errorf("cannot use unset value with ProtocolVersion OSS 3"),
 				},
 				{
 					"value empty",
@@ -223,7 +223,7 @@ func TestWriteValue(t *testing.T) {
 					"empty value with type unset",
 					&Value{Type: ValueTypeUnset},
 					nil,
-					errors.New("cannot use unset value in protocol version: 3"),
+					errors.New("cannot use unset value with ProtocolVersion OSS 3"),
 				},
 				{
 					"empty value with type unset but non nil contents",
@@ -232,7 +232,7 @@ func TestWriteValue(t *testing.T) {
 						Contents: []byte{1, 2, 3, 4},
 					},
 					nil,
-					errors.New("cannot use unset value in protocol version: 3"),
+					errors.New("cannot use unset value with ProtocolVersion OSS 3"),
 				},
 				{
 					"unknown type",


### PR DESCRIPTION
I would like to switch from type aliases to true types for types like `OpCode`, etc.

The main reason is that when debugging, it's hard to guess what an opcode 15 is, however if the error message says `OpCode AUTH RESPONSE [0x0F]` it becomes way easier to understand what's going on.