### PR TITLE
Add clone functions for most types

### DIFF
--- a/datatype/custom.go
+++ b/datatype/custom.go
@@ -42,6 +42,12 @@ func (t *customType) GetDataTypeCode() primitive.DataTypeCode {
 	return primitive.DataTypeCodeCustom
 }
 
+func (t *customType) Clone() DataType {
+	return &customType{
+		className: t.className,
+	}
+}
+
 func (t *customType) String() string {
 	return fmt.Sprintf("custom(%v)", t.className)
 }

--- a/datatype/custom_test.go
+++ b/datatype/custom_test.go
@@ -116,3 +116,11 @@ func TestCustomTypeCodecDecode(t *testing.T) {
 		})
 	}
 }
+
+func TestCustomTypeClone(t *testing.T) {
+	ct := NewCustomType("foo.bar.qix")
+	clonedCustomType := ct.Clone().(*customType)
+	clonedCustomType.className = "123"
+	assert.Equal(t, "123", clonedCustomType.GetClassName())
+	assert.Equal(t, "foo.bar.qix", ct.GetClassName())
+}

--- a/datatype/datatype.go
+++ b/datatype/datatype.go
@@ -22,6 +22,7 @@ import (
 
 type DataType interface {
 	GetDataTypeCode() primitive.DataTypeCode
+	Clone() DataType
 }
 
 type encoder interface {

--- a/datatype/list.go
+++ b/datatype/list.go
@@ -42,6 +42,12 @@ func (t *listType) GetDataTypeCode() primitive.DataTypeCode {
 	return primitive.DataTypeCodeList
 }
 
+func (t *listType) Clone() DataType {
+	return &listType{
+		elementType: t.elementType.Clone(),
+	}
+}
+
 func (t *listType) String() string {
 	return fmt.Sprintf("list<%v>", t.elementType)
 }

--- a/datatype/list_test.go
+++ b/datatype/list_test.go
@@ -29,6 +29,16 @@ func TestListType(t *testing.T) {
 	assert.Equal(t, Varchar, listType.GetElementType())
 }
 
+func TestListTypeClone(t *testing.T) {
+	lt := NewListType(Varchar)
+	clonedObj := lt.Clone().(*listType)
+	clonedObj.elementType = Int
+	assert.Equal(t, primitive.DataTypeCodeList, lt.GetDataTypeCode())
+	assert.Equal(t, Varchar, lt.GetElementType())
+	assert.Equal(t, primitive.DataTypeCodeList, clonedObj.GetDataTypeCode())
+	assert.Equal(t, Int, clonedObj.GetElementType())
+}
+
 func TestListTypeCodecEncode(t *testing.T) {
 	for _, version := range primitive.AllProtocolVersions() {
 		t.Run(version.String(), func(t *testing.T) {

--- a/datatype/map.go
+++ b/datatype/map.go
@@ -44,6 +44,13 @@ func (t *mapType) GetDataTypeCode() primitive.DataTypeCode {
 	return primitive.DataTypeCodeMap
 }
 
+func (t *mapType) Clone() DataType {
+	return &mapType{
+		keyType:   t.keyType.Clone(),
+		valueType: t.valueType.Clone(),
+	}
+}
+
 func (t *mapType) String() string {
 	return fmt.Sprintf("map<%v,%v>", t.keyType, t.valueType)
 }

--- a/datatype/map_test.go
+++ b/datatype/map_test.go
@@ -30,6 +30,19 @@ func TestMapType(t *testing.T) {
 	assert.Equal(t, Int, mapType.GetValueType())
 }
 
+func TestMapTypeClone(t *testing.T) {
+	mt := NewMapType(Varchar, Int)
+	cloned := mt.Clone().(*mapType)
+	cloned.keyType = Inet
+	cloned.valueType = Uuid
+	assert.Equal(t, primitive.DataTypeCodeMap, mt.GetDataTypeCode())
+	assert.Equal(t, Varchar, mt.GetKeyType())
+	assert.Equal(t, Int, mt.GetValueType())
+	assert.Equal(t, primitive.DataTypeCodeMap, cloned.GetDataTypeCode())
+	assert.Equal(t, Inet, cloned.GetKeyType())
+	assert.Equal(t, Uuid, cloned.GetValueType())
+}
+
 func TestMapTypeCodecEncode(t *testing.T) {
 	for _, version := range primitive.AllProtocolVersions() {
 		t.Run(version.String(), func(t *testing.T) {

--- a/datatype/primitive.go
+++ b/datatype/primitive.go
@@ -56,6 +56,12 @@ func (t *primitiveType) GetDataTypeCode() primitive.DataTypeCode {
 	return t.code
 }
 
+func (t *primitiveType) Clone() DataType {
+	return &primitiveType{
+		code: t.code,
+	}
+}
+
 func (t *primitiveType) String() string {
 	switch t.GetDataTypeCode() {
 	case primitive.DataTypeCodeAscii:

--- a/datatype/set.go
+++ b/datatype/set.go
@@ -38,6 +38,12 @@ func (t *setType) GetDataTypeCode() primitive.DataTypeCode {
 	return primitive.DataTypeCodeSet
 }
 
+func (t *setType) Clone() DataType {
+	return &setType{
+		elementType: t.elementType.Clone(),
+	}
+}
+
 func (t *setType) String() string {
 	return fmt.Sprintf("set<%v>", t.elementType)
 }

--- a/datatype/set_test.go
+++ b/datatype/set_test.go
@@ -29,6 +29,16 @@ func TestSetType(t *testing.T) {
 	assert.Equal(t, Varchar, setType.GetElementType())
 }
 
+func TestSetTypeClone(t *testing.T) {
+	st := NewSetType(Varchar)
+	cloned := st.Clone().(*setType)
+	cloned.elementType = Int
+	assert.Equal(t, primitive.DataTypeCodeSet, st.GetDataTypeCode())
+	assert.Equal(t, Varchar, st.GetElementType())
+	assert.Equal(t, primitive.DataTypeCodeSet, cloned.GetDataTypeCode())
+	assert.Equal(t, Int, cloned.GetElementType())
+}
+
 func TestSetTypeCodecEncode(t *testing.T) {
 	for _, version := range primitive.AllProtocolVersions() {
 		t.Run(version.String(), func(t *testing.T) {

--- a/datatype/tuple.go
+++ b/datatype/tuple.go
@@ -42,6 +42,20 @@ func (t *tupleType) GetDataTypeCode() primitive.DataTypeCode {
 	return primitive.DataTypeCodeTuple
 }
 
+func (t *tupleType) Clone() DataType {
+	var newFieldTypes []DataType
+	if t.fieldTypes != nil {
+		newFieldTypes = make([]DataType, len(t.fieldTypes))
+		copy(newFieldTypes, t.fieldTypes)
+	} else {
+		newFieldTypes = nil
+	}
+
+	return &tupleType{
+		fieldTypes: newFieldTypes,
+	}
+}
+
 func (t *tupleType) String() string {
 	return fmt.Sprintf("tuple<%v>", t.fieldTypes)
 }

--- a/datatype/tuple_test.go
+++ b/datatype/tuple_test.go
@@ -29,6 +29,16 @@ func TestTupleType(t *testing.T) {
 	assert.Equal(t, []DataType{Varchar, Int}, tupleType.GetFieldTypes())
 }
 
+func TestTupleTypeClone(t *testing.T) {
+	tt := NewTupleType(Varchar, Int)
+	cloned := tt.Clone().(*tupleType)
+	cloned.fieldTypes = []DataType{Int, Uuid, Float}
+	assert.Equal(t, primitive.DataTypeCodeTuple, tt.GetDataTypeCode())
+	assert.Equal(t, []DataType{Varchar, Int}, tt.GetFieldTypes())
+	assert.Equal(t, primitive.DataTypeCodeTuple, cloned.GetDataTypeCode())
+	assert.Equal(t, []DataType{Int, Uuid, Float}, cloned.GetFieldTypes())
+}
+
 func TestTupleTypeCodecEncode(t *testing.T) {
 	for _, version := range primitive.AllProtocolVersions() {
 		t.Run(version.String(), func(t *testing.T) {

--- a/datatype/udt.go
+++ b/datatype/udt.go
@@ -66,6 +66,23 @@ func (t *userDefinedType) GetDataTypeCode() primitive.DataTypeCode {
 	return primitive.DataTypeCodeUdt
 }
 
+func (t *userDefinedType) Clone() DataType {
+	var newDataTypes []DataType
+	if t.fieldTypes != nil {
+		newDataTypes = make([]DataType, len(t.fieldTypes))
+		copy(newDataTypes, t.fieldTypes)
+	} else {
+		newDataTypes = nil
+	}
+
+	return &userDefinedType{
+		keyspace:   t.keyspace,
+		name:       t.name,
+		fieldNames: primitive.CloneStringSlice(t.fieldNames),
+		fieldTypes: newDataTypes,
+	}
+}
+
 func (t *userDefinedType) String() string {
 	return fmt.Sprintf("%v.%v<%v>", t.keyspace, t.name, t.fieldTypes)
 }

--- a/datatype/udt_test.go
+++ b/datatype/udt_test.go
@@ -35,6 +35,31 @@ func TestUserDefinedType(t *testing.T) {
 	assert.Errorf(t, err2, "field names and field types length mismatch: 2 != 3")
 }
 
+func TestUserDefinedTypeClone(t *testing.T) {
+	fieldNames := []string{"f1", "f2"}
+	fieldTypes := []DataType{Varchar, Int}
+	udtType, err := NewUserDefinedType("ks1", "udt1", fieldNames, fieldTypes)
+	assert.Nil(t, err)
+
+	cloned := udtType.Clone().(*userDefinedType)
+	cloned.name = "udt2"
+	cloned.keyspace = "ks2"
+	cloned.fieldNames = []string{"f5", "field6", "f7"}
+	cloned.fieldTypes = []DataType{Uuid, Float, Varchar}
+
+	assert.Equal(t, primitive.DataTypeCodeUdt, udtType.GetDataTypeCode())
+	assert.Equal(t, []DataType{Varchar, Int}, udtType.GetFieldTypes())
+	assert.Equal(t, []string{"f1", "f2"}, udtType.GetFieldNames())
+	assert.Equal(t, "ks1", udtType.GetKeyspace())
+	assert.Equal(t, "udt1", udtType.GetName())
+
+	assert.Equal(t, primitive.DataTypeCodeUdt, cloned.GetDataTypeCode())
+	assert.Equal(t, []DataType{Uuid, Float, Varchar}, cloned.GetFieldTypes())
+	assert.Equal(t, []string{"f5", "field6", "f7"}, cloned.GetFieldNames())
+	assert.Equal(t, "ks2", cloned.GetKeyspace())
+	assert.Equal(t, "udt2", cloned.GetName())
+}
+
 var udt1, _ = NewUserDefinedType("ks1", "udt1", []string{"f1", "f2"}, []DataType{Varchar, Int})
 var udt2, _ = NewUserDefinedType("ks1", "udt2", []string{"f1"}, []DataType{udt1})
 

--- a/frame/frame.go
+++ b/frame/frame.go
@@ -146,6 +146,14 @@ func (f *Frame) String() string {
 	return fmt.Sprintf("{header: %v, body: %v}", f.Header, f.Body)
 }
 
+// Performs a deep copy of a frame object
+func (f* Frame) Clone() *Frame {
+	return &Frame{
+		Header: f.Header.Clone(),
+		Body:   f.Body.Clone(),
+	}
+}
+
 // Performs a deep copy of a header object and returns the new object.
 func (h *Header) Clone() *Header {
 	newHeader := *h // it's only value types so this is fine
@@ -160,7 +168,7 @@ func (b *Body) Clone() *Body {
 	if b.CustomPayload == nil {
 		customPayload = nil
 	} else {
-		customPayload := make(map[string][]byte)
+		customPayload = make(map[string][]byte)
 		for key, value := range b.CustomPayload {
 			newValue := make([]byte, len(value))
 			copy(newValue, value)
@@ -172,7 +180,7 @@ func (b *Body) Clone() *Body {
 	if b.Warnings == nil {
 		warnings = nil
 	} else {
-		warnings := make([]string, len(b.Warnings))
+		warnings = make([]string, len(b.Warnings))
 		copy(warnings, b.Warnings)
 	}
 
@@ -215,6 +223,14 @@ func (f *RawFrame) Dump() (string, error) {
 		return "", err
 	} else {
 		return hex.Dump(buffer.Bytes()), nil
+	}
+}
+
+// Performs a deep copy of a RawFrame object
+func (f *RawFrame) Clone() *RawFrame {
+	return &RawFrame{
+		Header: f.Header.Clone(),
+		Body:   primitive.CloneByteSlice(f.Body),
 	}
 }
 

--- a/frame/frame.go
+++ b/frame/frame.go
@@ -146,6 +146,44 @@ func (f *Frame) String() string {
 	return fmt.Sprintf("{header: %v, body: %v}", f.Header, f.Body)
 }
 
+// Performs a deep copy of a header object and returns the new object.
+func (h *Header) Clone() *Header {
+	newHeader := *h // it's only value types so this is fine
+	return &newHeader
+}
+
+// Performs a deep copy of a body object and returns the new object.
+func (b *Body) Clone() *Body {
+	newUuid := b.TracingId.Clone()
+
+	var customPayload map[string][]byte
+	if b.CustomPayload == nil {
+		customPayload = nil
+	} else {
+		customPayload := make(map[string][]byte)
+		for key, value := range b.CustomPayload {
+			newValue := make([]byte, len(value))
+			copy(newValue, value)
+			customPayload[key] = newValue
+		}
+	}
+
+	var warnings []string
+	if b.Warnings == nil {
+		warnings = nil
+	} else {
+		warnings := make([]string, len(b.Warnings))
+		copy(warnings, b.Warnings)
+	}
+
+	return &Body{
+		TracingId:     &newUuid,
+		CustomPayload: customPayload,
+		Warnings:      warnings,
+		Message:       b.Message.Clone(),
+	}
+}
+
 func (f *RawFrame) String() string {
 	return fmt.Sprintf("{header: %v, body: %v}", f.Header, f.Body)
 }

--- a/frame/frame_test.go
+++ b/frame/frame_test.go
@@ -1,0 +1,125 @@
+package frame
+
+import (
+	"github.com/datastax/go-cassandra-native-protocol/message"
+	"github.com/datastax/go-cassandra-native-protocol/primitive"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestFrame_Clone(t *testing.T) {
+	f := NewFrame(primitive.ProtocolVersion4, 1, &message.Ready{})
+	f.SetTracingId(&primitive.UUID{0x01, 0x02})
+
+	cloned := f.Clone()
+	assert.Equal(t, f, cloned)
+
+	cloned.SetTracingId(&primitive.UUID{0x02, 0x03})
+	assert.Equal(t, primitive.ProtocolVersion4, f.Header.Version)
+	assert.Equal(t, &primitive.UUID{0x01, 0x02}, f.Body.TracingId)
+
+	assert.NotEqual(t, f, cloned)
+	assert.Equal(t, primitive.ProtocolVersion4, cloned.Header.Version)
+	assert.Equal(t, &primitive.UUID{0x02, 0x03}, cloned.Body.TracingId)
+}
+
+func TestRawFrame_Clone(t *testing.T) {
+	f := &RawFrame{
+		Header: &Header{
+			IsResponse: true,
+			Version:    primitive.ProtocolVersion4,
+			Flags:      0,
+			StreamId:   1,
+			OpCode:     primitive.OpCodeError,
+			BodyLength: 1,
+		},
+		Body:   []byte{0x01},
+	}
+
+	cloned := f.Clone()
+	assert.Equal(t, f, cloned)
+
+	cloned.Body = []byte{0x03, 0x04}
+	assert.Equal(t, primitive.ProtocolVersion4, f.Header.Version)
+	assert.Equal(t, []byte{0x01}, f.Body)
+
+	assert.NotEqual(t, f, cloned)
+	assert.Equal(t, primitive.ProtocolVersion4, cloned.Header.Version)
+	assert.Equal(t, []byte{0x03, 0x04}, cloned.Body)
+}
+
+func TestHeader_Clone(t *testing.T) {
+	h := &Header{
+		IsResponse: true,
+		Version:    primitive.ProtocolVersion4,
+		Flags:      0,
+		StreamId:   1,
+		OpCode:     primitive.OpCodeError,
+		BodyLength: 1,
+	}
+
+	cloned := h.Clone()
+	assert.Equal(t, h, cloned)
+
+	cloned.IsResponse = false
+	cloned.Version = primitive.ProtocolVersion3
+	cloned.Flags = primitive.HeaderFlagTracing
+	cloned.StreamId = 2
+	cloned.OpCode = primitive.OpCodeStartup
+	cloned.BodyLength = 2
+
+	assert.NotEqual(t, h, cloned)
+	assert.Equal(t, true, h.IsResponse)
+	assert.Equal(t, primitive.ProtocolVersion4, h.Version)
+	assert.EqualValues(t, 0, h.Flags)
+	assert.EqualValues(t, 1, h.StreamId)
+	assert.Equal(t, primitive.OpCodeError, h.OpCode)
+	assert.EqualValues(t, 1, h.BodyLength)
+
+	assert.Equal(t, false, cloned.IsResponse)
+	assert.Equal(t, primitive.ProtocolVersion3, cloned.Version)
+	assert.EqualValues(t, primitive.HeaderFlagTracing, cloned.Flags)
+	assert.EqualValues(t, 2, cloned.StreamId)
+	assert.Equal(t, primitive.OpCodeStartup, cloned.OpCode)
+	assert.EqualValues(t, 2, cloned.BodyLength)
+}
+
+func TestBody_Clone(t *testing.T) {
+	b := &Body{
+		TracingId:     &primitive.UUID{0x01},
+		CustomPayload: map[string][]byte{
+			"opt1": {0x05},
+		},
+		Warnings:      []string{"warn"},
+		Message:       &message.Query{
+			Query:   "q1",
+		},
+	}
+
+	cloned := b.Clone()
+	assert.Equal(t, b, cloned)
+
+	cloned.TracingId = &primitive.UUID{0x03}
+	cloned.CustomPayload["opt1"] = []byte{0x01}
+	cloned.CustomPayload["opt2"] = []byte{0x06}
+	cloned.Warnings = []string{"w1", "w2"}
+	cloned.Message.(*message.Query).Query = "q2"
+
+	assert.NotEqual(t, b, cloned)
+
+	assert.Equal(t, &primitive.UUID{0x01}, b.TracingId)
+	assert.Equal(t, []byte{0x05}, b.CustomPayload["opt1"])
+	assert.Equal(t, 1, len(b.CustomPayload))
+	assert.Equal(t, "warn", b.Warnings[0])
+	assert.Equal(t, 1, len(b.Warnings))
+	assert.Equal(t, "q1", b.Message.(*message.Query).Query)
+
+	assert.Equal(t, &primitive.UUID{0x03}, cloned.TracingId)
+	assert.Equal(t, []byte{0x01}, cloned.CustomPayload["opt1"])
+	assert.Equal(t, []byte{0x06}, cloned.CustomPayload["opt2"])
+	assert.Equal(t, 2, len(cloned.CustomPayload))
+	assert.Equal(t, "w1", cloned.Warnings[0])
+	assert.Equal(t, "w2", cloned.Warnings[1])
+	assert.Equal(t, 2, len(cloned.Warnings))
+	assert.Equal(t, "q2", cloned.Message.(*message.Query).Query)
+}

--- a/message/auth_challenge.go
+++ b/message/auth_challenge.go
@@ -37,6 +37,13 @@ func (m *AuthChallenge) String() string {
 	return "AUTH_CHALLENGE"
 }
 
+// Performs a deep copy of this message object.
+func (m *AuthChallenge) Clone() Message {
+	return &AuthChallenge{
+		Token: primitive.CloneByteSlice(m.Token),
+	}
+}
+
 type authChallengeCodec struct{}
 
 func (c *authChallengeCodec) Encode(msg Message, dest io.Writer, _ primitive.ProtocolVersion) error {

--- a/message/auth_challenge_test.go
+++ b/message/auth_challenge_test.go
@@ -22,6 +22,19 @@ import (
 	"testing"
 )
 
+func TestAuthChallenge_Clone(t *testing.T) {
+	token := []byte{0xca, 0xfe, 0xba, 0xbe}
+	msg := &AuthChallenge{
+		Token: token,
+	}
+	cloned := msg.Clone().(*AuthChallenge)
+	assert.Equal(t, msg, cloned)
+	cloned.Token = []byte{0xcb, 0xfd, 0xbc, 0xba}
+	assert.Equal(t, []byte{0xca, 0xfe, 0xba, 0xbe}, token)
+	assert.Equal(t, []byte{0xcb, 0xfd, 0xbc, 0xba}, cloned.Token)
+	assert.NotEqual(t, msg, cloned)
+}
+
 func TestAuthChallengeCodec_Encode(t *testing.T) {
 	token := []byte{0xca, 0xfe, 0xba, 0xbe}
 	codec := &authChallengeCodec{}

--- a/message/auth_response.go
+++ b/message/auth_response.go
@@ -37,6 +37,13 @@ func (m *AuthResponse) String() string {
 	return "AUTH_RESPONSE"
 }
 
+// Performs a deep copy of this message object.
+func (m *AuthResponse) Clone() Message {
+	return &AuthResponse{
+		Token: primitive.CloneByteSlice(m.Token),
+	}
+}
+
 type authResponseCodec struct{}
 
 func (c *authResponseCodec) Encode(msg Message, dest io.Writer, _ primitive.ProtocolVersion) error {

--- a/message/auth_response_test.go
+++ b/message/auth_response_test.go
@@ -22,6 +22,19 @@ import (
 	"testing"
 )
 
+func TestAuthResponse_Clone(t *testing.T) {
+	token := []byte{0xca, 0xfe, 0xba, 0xbe}
+	msg := &AuthResponse{
+		Token: token,
+	}
+	cloned := msg.Clone().(*AuthResponse)
+	assert.Equal(t, msg, cloned)
+	cloned.Token = []byte{0xcb, 0xfd, 0xbc, 0xba}
+	assert.Equal(t, []byte{0xca, 0xfe, 0xba, 0xbe}, token)
+	assert.Equal(t, []byte{0xcb, 0xfd, 0xbc, 0xba}, cloned.Token)
+	assert.NotEqual(t, msg, cloned)
+}
+
 func TestAuthResponseCodec_Encode(t *testing.T) {
 	token := []byte{0xca, 0xfe, 0xba, 0xbe}
 	codec := &authResponseCodec{}

--- a/message/auth_success.go
+++ b/message/auth_success.go
@@ -37,6 +37,13 @@ func (m *AuthSuccess) String() string {
 	return "AUTH_SUCCESS"
 }
 
+// Performs a deep copy of this message object.
+func (m *AuthSuccess) Clone() Message {
+	return &AuthSuccess{
+		Token: primitive.CloneByteSlice(m.Token),
+	}
+}
+
 type authSuccessCodec struct{}
 
 func (c *authSuccessCodec) Encode(msg Message, dest io.Writer, _ primitive.ProtocolVersion) error {

--- a/message/auth_success_test.go
+++ b/message/auth_success_test.go
@@ -22,6 +22,19 @@ import (
 	"testing"
 )
 
+func TestAuthSuccess_Clone(t *testing.T) {
+	token := []byte{0xca, 0xfe, 0xba, 0xbe}
+	msg := &AuthSuccess{
+		Token: token,
+	}
+	cloned := msg.Clone().(*AuthSuccess)
+	assert.Equal(t, msg, cloned)
+	cloned.Token = []byte{0xcb, 0xfd, 0xbc, 0xba}
+	assert.Equal(t, []byte{0xca, 0xfe, 0xba, 0xbe}, token)
+	assert.Equal(t, []byte{0xcb, 0xfd, 0xbc, 0xba}, cloned.Token)
+	assert.NotEqual(t, msg, cloned)
+}
+
 func TestAuthSuccessCodec_Encode(t *testing.T) {
 	token := []byte{0xca, 0xfe, 0xba, 0xbe}
 	codec := &authSuccessCodec{}

--- a/message/authenticate.go
+++ b/message/authenticate.go
@@ -37,6 +37,12 @@ func (m *Authenticate) String() string {
 	return "AUTHENTICATE " + m.Authenticator
 }
 
+// Performs a deep copy of this message object.
+func (m *Authenticate) Clone() Message {
+	newMsg := *m
+	return &newMsg
+}
+
 type authenticateCodec struct{}
 
 func (c *authenticateCodec) Encode(msg Message, dest io.Writer, _ primitive.ProtocolVersion) error {

--- a/message/authenticate_test.go
+++ b/message/authenticate_test.go
@@ -22,6 +22,18 @@ import (
 	"testing"
 )
 
+func TestAuthenticate_Clone(t *testing.T) {
+	msg := &Authenticate{
+		Authenticator: "auth",
+	}
+	cloned := msg.Clone().(*Authenticate)
+	assert.Equal(t, msg, cloned)
+	cloned.Authenticator = "auth2"
+	assert.Equal(t, "auth", msg.Authenticator)
+	assert.Equal(t, "auth2", cloned.Authenticator)
+	assert.NotEqual(t, msg, cloned)
+}
+
 func TestAuthenticateCodec_Encode(t *testing.T) {
 	codec := &authenticateCodec{}
 	for _, version := range primitive.AllProtocolVersions() {

--- a/message/batch.go
+++ b/message/batch.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/datastax/go-cassandra-native-protocol/primitive"
+	"github.com/rs/zerolog/log"
 	"io"
 )
 
@@ -80,6 +81,29 @@ func (m *Batch) Flags() primitive.QueryFlag {
 	return flags
 }
 
+// Performs a deep copy of this batch message object
+func (m *Batch) Clone() Message {
+	var newBatchChildren []*BatchChild
+	if m.Children != nil {
+		newBatchChildren = make([]*BatchChild, len(m.Children))
+		for idx, child := range m.Children {
+			newBatchChildren[idx] = child.Clone()
+		}
+	} else {
+		newBatchChildren = nil
+	}
+
+	return &Batch{
+		Type:              m.Type,
+		Children:          newBatchChildren,
+		Consistency:       m.Consistency,
+		SerialConsistency: primitive.CloneNillableConsistencyLevel(m.SerialConsistency),
+		DefaultTimestamp:  primitive.CloneNillableInt64(m.DefaultTimestamp),
+		Keyspace:          m.Keyspace,
+		NowInSeconds:      primitive.CloneNillableInt32(m.NowInSeconds),
+	}
+}
+
 type BatchChild struct {
 	// Either a string or []byte; the former should be the CQL statement to execute, the latter the prepared id of
 	// the statement to execute.
@@ -87,6 +111,28 @@ type BatchChild struct {
 	// Note: named values are in theory possible, but their server-side implementation is
 	// broken. See https://issues.apache.org/jira/browse/CASSANDRA-10246
 	Values []*primitive.Value
+}
+
+func (c *BatchChild) Clone() *BatchChild {
+	var newQueryOrId interface{}
+	if c.QueryOrId != nil {
+		switch queryOrId := c.QueryOrId.(type) {
+		case string:
+			newQueryOrId = queryOrId
+		case []byte:
+			newQueryOrId = primitive.CloneByteSlice(queryOrId)
+		default:
+			log.Error().Msgf("could not clone QueryOrId, unexpected type: %T", queryOrId)
+			newQueryOrId = c.QueryOrId
+		}
+	} else {
+		newQueryOrId = nil
+	}
+
+	return &BatchChild{
+		QueryOrId: newQueryOrId,
+		Values:    CloneValuesSlice(c.Values),
+	}
 }
 
 type batchCodec struct{}

--- a/message/dse_continuous_paging_options.go
+++ b/message/dse_continuous_paging_options.go
@@ -35,6 +35,15 @@ type ContinuousPagingOptions struct {
 	NextPages int32
 }
 
+func CloneContinuousPagingOptions(options *ContinuousPagingOptions) *ContinuousPagingOptions {
+	if options == nil {
+		return nil
+	}
+
+	newObj := *options
+	return &newObj
+}
+
 func EncodeContinuousPagingOptions(options *ContinuousPagingOptions, dest io.Writer, version primitive.ProtocolVersion) (err error) {
 	if err = primitive.CheckValidDseProtocolVersion(version); err != nil {
 		return err

--- a/message/dse_continuous_paging_options_test.go
+++ b/message/dse_continuous_paging_options_test.go
@@ -21,6 +21,26 @@ import (
 	"testing"
 )
 
+func TestCloneContinuousPagingOptions(t *testing.T) {
+	obj := &ContinuousPagingOptions{
+		MaxPages:       1,
+		PagesPerSecond: 2,
+		NextPages:      3,
+	}
+	cloned := CloneContinuousPagingOptions(obj)
+	assert.Equal(t, obj, cloned)
+	cloned.MaxPages = 5
+	cloned.PagesPerSecond = 6
+	cloned.NextPages = 7
+	assert.NotEqual(t, obj, cloned)
+	assert.EqualValues(t, 1, obj.MaxPages)
+	assert.EqualValues(t, 2, obj.PagesPerSecond)
+	assert.EqualValues(t, 3, obj.NextPages)
+	assert.EqualValues(t, 5, cloned.MaxPages)
+	assert.EqualValues(t, 6, cloned.PagesPerSecond)
+	assert.EqualValues(t, 7, cloned.NextPages)
+}
+
 func TestContinuousPagingOptions_Encode(t *testing.T) {
 	version := primitive.ProtocolVersionDse1
 	t.Run(version.String(), func(t *testing.T) {

--- a/message/dse_revise_request.go
+++ b/message/dse_revise_request.go
@@ -38,6 +38,11 @@ func (m *Revise) GetOpCode() primitive.OpCode {
 	return primitive.OpCodeDseRevise
 }
 
+func (m *Revise) Clone() Message {
+	newObj := *m
+	return &newObj
+}
+
 func (m *Revise) String() string {
 	return fmt.Sprintf("REVISE_REQUEST operation type: %v, stream id: %v", m.RevisionType, m.TargetStreamId)
 }

--- a/message/dse_revise_request_test.go
+++ b/message/dse_revise_request_test.go
@@ -22,6 +22,26 @@ import (
 	"testing"
 )
 
+func TestRevise_Clone(t *testing.T) {
+	obj := &Revise{
+		RevisionType:   primitive.DseRevisionTypeCancelContinuousPaging,
+		TargetStreamId: 5,
+		NextPages:      10,
+	}
+	cloned := obj.Clone().(*Revise)
+	assert.Equal(t, obj, cloned)
+	cloned.RevisionType = primitive.DseRevisionTypeMoreContinuousPages
+	cloned.TargetStreamId = 6
+	cloned.NextPages = 7
+	assert.NotEqual(t, obj, cloned)
+	assert.Equal(t, primitive.DseRevisionTypeCancelContinuousPaging, obj.RevisionType)
+	assert.EqualValues(t, 5, obj.TargetStreamId)
+	assert.EqualValues(t, 10, obj.NextPages)
+	assert.Equal(t, primitive.DseRevisionTypeMoreContinuousPages, cloned.RevisionType)
+	assert.EqualValues(t, 6, cloned.TargetStreamId)
+	assert.EqualValues(t, 7, cloned.NextPages)
+}
+
 func TestReviseCodec_Encode(t *testing.T) {
 	codec := &reviseCodec{}
 	version := primitive.ProtocolVersionDse1

--- a/message/error.go
+++ b/message/error.go
@@ -40,6 +40,11 @@ func (m *ServerError) GetOpCode() primitive.OpCode {
 	return primitive.OpCodeError
 }
 
+func (m *ServerError) Clone() Message {
+	newObj := *m
+	return &newObj
+}
+
 func (m *ServerError) GetErrorCode() primitive.ErrorCode {
 	return primitive.ErrorCodeServerError
 }
@@ -64,6 +69,11 @@ func (m *ProtocolError) IsResponse() bool {
 
 func (m *ProtocolError) GetOpCode() primitive.OpCode {
 	return primitive.OpCodeError
+}
+
+func (m *ProtocolError) Clone() Message {
+	newObj := *m
+	return &newObj
 }
 
 func (m *ProtocolError) GetErrorCode() primitive.ErrorCode {
@@ -92,6 +102,11 @@ func (m *AuthenticationError) GetOpCode() primitive.OpCode {
 	return primitive.OpCodeError
 }
 
+func (m *AuthenticationError) Clone() Message {
+	newObj := *m
+	return &newObj
+}
+
 func (m *AuthenticationError) GetErrorCode() primitive.ErrorCode {
 	return primitive.ErrorCodeAuthenticationError
 }
@@ -116,6 +131,11 @@ func (m *Overloaded) IsResponse() bool {
 
 func (m *Overloaded) GetOpCode() primitive.OpCode {
 	return primitive.OpCodeError
+}
+
+func (m *Overloaded) Clone() Message {
+	newObj := *m
+	return &newObj
 }
 
 func (m *Overloaded) GetErrorCode() primitive.ErrorCode {
@@ -144,6 +164,11 @@ func (m *IsBootstrapping) GetOpCode() primitive.OpCode {
 	return primitive.OpCodeError
 }
 
+func (m *IsBootstrapping) Clone() Message {
+	newObj := *m
+	return &newObj
+}
+
 func (m *IsBootstrapping) GetErrorCode() primitive.ErrorCode {
 	return primitive.ErrorCodeIsBootstrapping
 }
@@ -168,6 +193,11 @@ func (m *TruncateError) IsResponse() bool {
 
 func (m *TruncateError) GetOpCode() primitive.OpCode {
 	return primitive.OpCodeError
+}
+
+func (m *TruncateError) Clone() Message {
+	newObj := *m
+	return &newObj
 }
 
 func (m *TruncateError) GetErrorCode() primitive.ErrorCode {
@@ -196,6 +226,11 @@ func (m *SyntaxError) GetOpCode() primitive.OpCode {
 	return primitive.OpCodeError
 }
 
+func (m *SyntaxError) Clone() Message {
+	newObj := *m
+	return &newObj
+}
+
 func (m *SyntaxError) GetErrorCode() primitive.ErrorCode {
 	return primitive.ErrorCodeSyntaxError
 }
@@ -220,6 +255,11 @@ func (m *Unauthorized) IsResponse() bool {
 
 func (m *Unauthorized) GetOpCode() primitive.OpCode {
 	return primitive.OpCodeError
+}
+
+func (m *Unauthorized) Clone() Message {
+	newObj := *m
+	return &newObj
 }
 
 func (m *Unauthorized) GetErrorCode() primitive.ErrorCode {
@@ -248,6 +288,11 @@ func (m *Invalid) GetOpCode() primitive.OpCode {
 	return primitive.OpCodeError
 }
 
+func (m *Invalid) Clone() Message {
+	newObj := *m
+	return &newObj
+}
+
 func (m *Invalid) GetErrorCode() primitive.ErrorCode {
 	return primitive.ErrorCodeInvalid
 }
@@ -272,6 +317,11 @@ func (m *ConfigError) IsResponse() bool {
 
 func (m *ConfigError) GetOpCode() primitive.OpCode {
 	return primitive.OpCodeError
+}
+
+func (m *ConfigError) Clone() Message {
+	newObj := *m
+	return &newObj
 }
 
 func (m *ConfigError) GetErrorCode() primitive.ErrorCode {
@@ -305,6 +355,11 @@ func (m *Unavailable) IsResponse() bool {
 
 func (m *Unavailable) GetOpCode() primitive.OpCode {
 	return primitive.OpCodeError
+}
+
+func (m *Unavailable) Clone() Message {
+	newObj := *m
+	return &newObj
 }
 
 func (m *Unavailable) GetErrorCode() primitive.ErrorCode {
@@ -351,6 +406,11 @@ func (m *ReadTimeout) GetOpCode() primitive.OpCode {
 	return primitive.OpCodeError
 }
 
+func (m *ReadTimeout) Clone() Message {
+	newObj := *m
+	return &newObj
+}
+
 func (m *ReadTimeout) GetErrorCode() primitive.ErrorCode {
 	return primitive.ErrorCodeReadTimeout
 }
@@ -391,6 +451,11 @@ func (m *WriteTimeout) IsResponse() bool {
 
 func (m *WriteTimeout) GetOpCode() primitive.OpCode {
 	return primitive.OpCodeError
+}
+
+func (m *WriteTimeout) Clone() Message {
+	newObj := *m
+	return &newObj
 }
 
 func (m *WriteTimeout) GetErrorCode() primitive.ErrorCode {
@@ -441,6 +506,19 @@ func (m *ReadFailure) GetOpCode() primitive.OpCode {
 	return primitive.OpCodeError
 }
 
+func (m *ReadFailure) Clone() Message {
+	newObj := &ReadFailure{
+		ErrorMessage:   m.ErrorMessage,
+		Consistency:    m.Consistency,
+		Received:       m.Received,
+		BlockFor:       m.BlockFor,
+		NumFailures:    m.NumFailures,
+		FailureReasons: cloneFailureReasons(m.FailureReasons),
+		DataPresent:    m.DataPresent,
+	}
+	return newObj
+}
+
 func (m *ReadFailure) GetErrorCode() primitive.ErrorCode {
 	return primitive.ErrorCodeReadFailure
 }
@@ -489,6 +567,18 @@ func (m *WriteFailure) GetOpCode() primitive.OpCode {
 	return primitive.OpCodeError
 }
 
+func (m *WriteFailure) Clone() Message {
+	return &WriteFailure{
+		ErrorMessage:   m.ErrorMessage,
+		Consistency:    m.Consistency,
+		Received:       m.Received,
+		BlockFor:       m.BlockFor,
+		NumFailures:    m.NumFailures,
+		FailureReasons: cloneFailureReasons(m.FailureReasons),
+		WriteType:      m.WriteType,
+	}
+}
+
 func (m *WriteFailure) GetErrorCode() primitive.ErrorCode {
 	return primitive.ErrorCodeWriteFailure
 }
@@ -526,6 +616,23 @@ func (m *FunctionFailure) GetOpCode() primitive.OpCode {
 	return primitive.OpCodeError
 }
 
+func (m *FunctionFailure) Clone() Message {
+	var arguments []string
+	if m.Arguments != nil {
+		arguments = make([]string, len(m.Arguments))
+		copy(arguments, m.Arguments)
+	} else {
+		arguments = nil
+	}
+
+	return &FunctionFailure{
+		ErrorMessage: m.ErrorMessage,
+		Keyspace:     m.Keyspace,
+		Function:     m.Function,
+		Arguments:    arguments,
+	}
+}
+
 func (m *FunctionFailure) GetErrorCode() primitive.ErrorCode {
 	return primitive.ErrorCodeFunctionFailure
 }
@@ -560,6 +667,13 @@ func (m *Unprepared) GetOpCode() primitive.OpCode {
 	return primitive.OpCodeError
 }
 
+func (m *Unprepared) Clone() Message {
+	return &Unprepared{
+		ErrorMessage: m.ErrorMessage,
+		Id:           primitive.CloneByteSlice(m.Id),
+	}
+}
+
 func (m *Unprepared) GetErrorCode() primitive.ErrorCode {
 	return primitive.ErrorCodeUnprepared
 }
@@ -591,6 +705,11 @@ func (m *AlreadyExists) IsResponse() bool {
 
 func (m *AlreadyExists) GetOpCode() primitive.OpCode {
 	return primitive.OpCodeError
+}
+
+func (m *AlreadyExists) Clone() Message {
+	newObj := *m
+	return &newObj
 }
 
 func (m *AlreadyExists) GetErrorCode() primitive.ErrorCode {
@@ -1072,4 +1191,15 @@ func (c *errorCodec) Decode(source io.Reader, version primitive.ProtocolVersion)
 
 func (c *errorCodec) GetOpCode() primitive.OpCode {
 	return primitive.OpCodeError
+}
+
+func cloneFailureReasons(failureReasons []*primitive.FailureReason) []*primitive.FailureReason {
+	var result []*primitive.FailureReason
+	if failureReasons != nil {
+		result = make([]*primitive.FailureReason, len(failureReasons))
+		copy(result, failureReasons)
+	} else {
+		result = nil
+	}
+	return result
 }

--- a/message/error_test.go
+++ b/message/error_test.go
@@ -23,6 +23,386 @@ import (
 	"testing"
 )
 
+func TestServerError_Clone(t *testing.T) {
+	msg := &ServerError{
+		ErrorMessage: "msg",
+	}
+	cloned := msg.Clone().(*ServerError)
+	assert.Equal(t, msg, cloned)
+	cloned.ErrorMessage = "alt msg"
+	assert.NotEqual(t, msg, cloned)
+	assert.Equal(t, "msg", msg.ErrorMessage)
+	assert.Equal(t, "alt msg", cloned.ErrorMessage)
+}
+
+func TestProtocolError_Clone(t *testing.T) {
+	msg := &ProtocolError{
+		ErrorMessage: "msg",
+	}
+	cloned := msg.Clone().(*ProtocolError)
+	assert.Equal(t, msg, cloned)
+	cloned.ErrorMessage = "alt msg"
+	assert.NotEqual(t, msg, cloned)
+	assert.Equal(t, "msg", msg.ErrorMessage)
+	assert.Equal(t, "alt msg", cloned.ErrorMessage)
+}
+
+func TestAuthenticationError_Clone(t *testing.T) {
+	msg := &AuthenticationError{
+		ErrorMessage: "msg",
+	}
+	cloned := msg.Clone().(*AuthenticationError)
+	assert.Equal(t, msg, cloned)
+	cloned.ErrorMessage = "alt msg"
+	assert.NotEqual(t, msg, cloned)
+	assert.Equal(t, "msg", msg.ErrorMessage)
+	assert.Equal(t, "alt msg", cloned.ErrorMessage)
+}
+
+func TestOverloaded_Clone(t *testing.T) {
+	msg := &Overloaded{
+		ErrorMessage: "msg",
+	}
+	cloned := msg.Clone().(*Overloaded)
+	assert.Equal(t, msg, cloned)
+	cloned.ErrorMessage = "alt msg"
+	assert.NotEqual(t, msg, cloned)
+	assert.Equal(t, "msg", msg.ErrorMessage)
+	assert.Equal(t, "alt msg", cloned.ErrorMessage)
+}
+
+func TestIsBootstrapping_Clone(t *testing.T) {
+	msg := &IsBootstrapping{
+		ErrorMessage: "msg",
+	}
+	cloned := msg.Clone().(*IsBootstrapping)
+	assert.Equal(t, msg, cloned)
+	cloned.ErrorMessage = "alt msg"
+	assert.NotEqual(t, msg, cloned)
+	assert.Equal(t, "msg", msg.ErrorMessage)
+	assert.Equal(t, "alt msg", cloned.ErrorMessage)
+}
+
+func TestTruncateError_Clone(t *testing.T) {
+	msg := &TruncateError{
+		ErrorMessage: "msg",
+	}
+	cloned := msg.Clone().(*TruncateError)
+	assert.Equal(t, msg, cloned)
+	cloned.ErrorMessage = "alt msg"
+	assert.NotEqual(t, msg, cloned)
+	assert.Equal(t, "msg", msg.ErrorMessage)
+	assert.Equal(t, "alt msg", cloned.ErrorMessage)
+}
+
+func TestSyntaxError_Clone(t *testing.T) {
+	msg := &SyntaxError{
+		ErrorMessage: "msg",
+	}
+	cloned := msg.Clone().(*SyntaxError)
+	assert.Equal(t, msg, cloned)
+	cloned.ErrorMessage = "alt msg"
+	assert.NotEqual(t, msg, cloned)
+	assert.Equal(t, "msg", msg.ErrorMessage)
+	assert.Equal(t, "alt msg", cloned.ErrorMessage)
+}
+
+func TestUnauthorized_Clone(t *testing.T) {
+	msg := &Unauthorized{
+		ErrorMessage: "msg",
+	}
+	cloned := msg.Clone().(*Unauthorized)
+	assert.Equal(t, msg, cloned)
+	cloned.ErrorMessage = "alt msg"
+	assert.NotEqual(t, msg, cloned)
+	assert.Equal(t, "msg", msg.ErrorMessage)
+	assert.Equal(t, "alt msg", cloned.ErrorMessage)
+}
+
+func TestInvalid_Clone(t *testing.T) {
+	msg := &Invalid{
+		ErrorMessage: "msg",
+	}
+	cloned := msg.Clone().(*Invalid)
+	assert.Equal(t, msg, cloned)
+	cloned.ErrorMessage = "alt msg"
+	assert.NotEqual(t, msg, cloned)
+	assert.Equal(t, "msg", msg.ErrorMessage)
+	assert.Equal(t, "alt msg", cloned.ErrorMessage)
+}
+
+func TestConfigError_Clone(t *testing.T) {
+	msg := &ConfigError{
+		ErrorMessage: "msg",
+	}
+	cloned := msg.Clone().(*ConfigError)
+	assert.Equal(t, msg, cloned)
+	cloned.ErrorMessage = "alt msg"
+	assert.NotEqual(t, msg, cloned)
+	assert.Equal(t, "msg", msg.ErrorMessage)
+	assert.Equal(t, "alt msg", cloned.ErrorMessage)
+}
+
+func TestUnavailable_Clone(t *testing.T) {
+	msg := &Unavailable{
+		ErrorMessage: "msg",
+		Consistency:  primitive.ConsistencyLevelAll,
+		Required:     2,
+		Alive:        1,
+	}
+	cloned := msg.Clone().(*Unavailable)
+	assert.Equal(t, msg, cloned)
+	cloned.ErrorMessage = "alt msg"
+	cloned.Consistency = primitive.ConsistencyLevelEachQuorum
+	cloned.Required = 3
+	cloned.Alive = 2
+	assert.NotEqual(t, msg, cloned)
+	assert.Equal(t, "msg", msg.ErrorMessage)
+	assert.Equal(t, primitive.ConsistencyLevelAll, msg.Consistency)
+	assert.EqualValues(t, 2, msg.Required)
+	assert.EqualValues(t, 1, msg.Alive)
+	assert.Equal(t, "alt msg", cloned.ErrorMessage)
+	assert.Equal(t, primitive.ConsistencyLevelEachQuorum, cloned.Consistency)
+	assert.EqualValues(t, 3, cloned.Required)
+	assert.EqualValues(t, 2, cloned.Alive)
+}
+
+func TestReadTimeout_Clone(t *testing.T) {
+	msg := &ReadTimeout{
+		ErrorMessage: "msg",
+		Consistency:  primitive.ConsistencyLevelAll,
+		Received:     3,
+		BlockFor:     4,
+		DataPresent:  false,
+	}
+	cloned := msg.Clone().(*ReadTimeout)
+	assert.Equal(t, msg, cloned)
+	cloned.ErrorMessage = "alt msg"
+	cloned.Consistency = primitive.ConsistencyLevelEachQuorum
+	cloned.Received = 2
+	cloned.BlockFor = 3
+	cloned.DataPresent = true
+	assert.NotEqual(t, msg, cloned)
+	assert.Equal(t, "msg", msg.ErrorMessage)
+	assert.Equal(t, primitive.ConsistencyLevelAll, msg.Consistency)
+	assert.EqualValues(t, 3, msg.Received)
+	assert.EqualValues(t, 4, msg.BlockFor)
+	assert.False(t, msg.DataPresent)
+	assert.Equal(t, "alt msg", cloned.ErrorMessage)
+	assert.Equal(t, primitive.ConsistencyLevelEachQuorum, cloned.Consistency)
+	assert.EqualValues(t, 2, cloned.Received)
+	assert.EqualValues(t, 3, cloned.BlockFor)
+	assert.True(t, cloned.DataPresent)
+}
+
+func TestWriteTimeout_Clone(t *testing.T) {
+	msg := &WriteTimeout{
+		ErrorMessage: "msg",
+		Consistency:  primitive.ConsistencyLevelAll,
+		Received:     5,
+		BlockFor:     6,
+		WriteType:    primitive.WriteTypeBatch,
+	}
+	cloned := msg.Clone().(*WriteTimeout)
+	assert.Equal(t, msg, cloned)
+	cloned.ErrorMessage = "alt msg"
+	cloned.Consistency = primitive.ConsistencyLevelEachQuorum
+	cloned.Received = 2
+	cloned.BlockFor = 3
+	cloned.WriteType = primitive.WriteTypeBatchLog
+	assert.NotEqual(t, msg, cloned)
+	assert.Equal(t, "msg", msg.ErrorMessage)
+	assert.Equal(t, primitive.ConsistencyLevelAll, msg.Consistency)
+	assert.EqualValues(t, 5, msg.Received)
+	assert.EqualValues(t, 6, msg.BlockFor)
+	assert.Equal(t, primitive.WriteTypeBatch, msg.WriteType)
+	assert.Equal(t, "alt msg", cloned.ErrorMessage)
+	assert.Equal(t, primitive.ConsistencyLevelEachQuorum, cloned.Consistency)
+	assert.EqualValues(t, 2, cloned.Received)
+	assert.EqualValues(t, 3, cloned.BlockFor)
+	assert.Equal(t, primitive.WriteTypeBatchLog, cloned.WriteType)
+}
+
+func TestReadFailure_Clone(t *testing.T) {
+	msg := &ReadFailure{
+		ErrorMessage:   "msg",
+		Consistency:    primitive.ConsistencyLevelAll,
+		Received:       1,
+		BlockFor:       2,
+		NumFailures:    1,
+		FailureReasons: []*primitive.FailureReason{
+			&primitive.FailureReason{
+				Endpoint: net.IP{0x01},
+				Code:     primitive.FailureCodeCdcSpaceFull,
+			},
+			&primitive.FailureReason{
+				Endpoint: net.IP{0x02},
+				Code:     primitive.FailureCodeCounterWrite,
+			},
+		},
+		DataPresent:    false,
+	}
+	cloned := msg.Clone().(*ReadFailure)
+	assert.Equal(t, msg, cloned)
+	cloned.ErrorMessage = "alt msg"
+	cloned.Consistency = primitive.ConsistencyLevelEachQuorum
+	cloned.Received = 2
+	cloned.BlockFor = 3
+	cloned.NumFailures = 2
+	cloned.FailureReasons = []*primitive.FailureReason{
+		&primitive.FailureReason{
+			Endpoint: net.IP{0x05},
+			Code:     primitive.FailureCodeIndexNotAvailable,
+		},
+		&primitive.FailureReason{
+			Endpoint: net.IP{0x06},
+			Code:     primitive.FailureCodeKeyspaceNotFound,
+		},
+	}
+	cloned.DataPresent = true
+	assert.NotEqual(t, msg, cloned)
+	assert.Equal(t, "msg", msg.ErrorMessage)
+	assert.Equal(t, primitive.ConsistencyLevelAll, msg.Consistency)
+	assert.EqualValues(t, 1, msg.Received)
+	assert.EqualValues(t, 2, msg.BlockFor)
+	assert.EqualValues(t, 1, msg.NumFailures)
+	assert.Equal(t, net.IP{0x01}, msg.FailureReasons[0].Endpoint)
+	assert.Equal(t, primitive.FailureCodeCdcSpaceFull, msg.FailureReasons[0].Code)
+	assert.Equal(t, net.IP{0x02}, msg.FailureReasons[1].Endpoint)
+	assert.Equal(t, primitive.FailureCodeCounterWrite, msg.FailureReasons[1].Code)
+	assert.False(t, msg.DataPresent)
+	assert.Equal(t, "alt msg", cloned.ErrorMessage)
+	assert.Equal(t, primitive.ConsistencyLevelEachQuorum, cloned.Consistency)
+	assert.EqualValues(t, 2, cloned.Received)
+	assert.EqualValues(t, 3, cloned.BlockFor)
+	assert.EqualValues(t, 2, cloned.NumFailures)
+	assert.Equal(t, net.IP{0x05}, cloned.FailureReasons[0].Endpoint)
+	assert.Equal(t, primitive.FailureCodeIndexNotAvailable, cloned.FailureReasons[0].Code)
+	assert.Equal(t, net.IP{0x06}, cloned.FailureReasons[1].Endpoint)
+	assert.Equal(t, primitive.FailureCodeKeyspaceNotFound, cloned.FailureReasons[1].Code)
+	assert.True(t, cloned.DataPresent)
+}
+
+func TestWriteFailure_Clone(t *testing.T) {
+	msg := &WriteFailure{
+		ErrorMessage: "msg",
+		Consistency:  primitive.ConsistencyLevelAll,
+		Received:     1,
+		BlockFor:     2,
+		NumFailures:  1,
+		FailureReasons: []*primitive.FailureReason{
+			&primitive.FailureReason{
+				Endpoint: net.IP{0x01},
+				Code:     primitive.FailureCodeCdcSpaceFull,
+			},
+			&primitive.FailureReason{
+				Endpoint: net.IP{0x02},
+				Code:     primitive.FailureCodeCounterWrite,
+			},
+		},
+		WriteType: primitive.WriteTypeBatchLog,
+	}
+	cloned := msg.Clone().(*WriteFailure)
+	assert.Equal(t, msg, cloned)
+	cloned.ErrorMessage = "alt msg"
+	cloned.Consistency = primitive.ConsistencyLevelEachQuorum
+	cloned.Received = 2
+	cloned.BlockFor = 3
+	cloned.NumFailures = 2
+	cloned.FailureReasons = []*primitive.FailureReason{
+		&primitive.FailureReason{
+			Endpoint: net.IP{0x05},
+			Code:     primitive.FailureCodeIndexNotAvailable,
+		},
+		&primitive.FailureReason{
+			Endpoint: net.IP{0x06},
+			Code:     primitive.FailureCodeKeyspaceNotFound,
+		},
+	}
+	cloned.WriteType = primitive.WriteTypeCdc
+	assert.NotEqual(t, msg, cloned)
+	assert.Equal(t, "msg", msg.ErrorMessage)
+	assert.Equal(t, primitive.ConsistencyLevelAll, msg.Consistency)
+	assert.EqualValues(t, 1, msg.Received)
+	assert.EqualValues(t, 2, msg.BlockFor)
+	assert.EqualValues(t, 1, msg.NumFailures)
+	assert.Equal(t, net.IP{0x01}, msg.FailureReasons[0].Endpoint)
+	assert.Equal(t, primitive.FailureCodeCdcSpaceFull, msg.FailureReasons[0].Code)
+	assert.Equal(t, net.IP{0x02}, msg.FailureReasons[1].Endpoint)
+	assert.Equal(t, primitive.FailureCodeCounterWrite, msg.FailureReasons[1].Code)
+	assert.Equal(t, primitive.WriteTypeBatchLog, msg.WriteType)
+	assert.Equal(t, "alt msg", cloned.ErrorMessage)
+	assert.Equal(t, primitive.ConsistencyLevelEachQuorum, cloned.Consistency)
+	assert.EqualValues(t, 2, cloned.Received)
+	assert.EqualValues(t, 3, cloned.BlockFor)
+	assert.EqualValues(t, 2, cloned.NumFailures)
+	assert.Equal(t, net.IP{0x05}, cloned.FailureReasons[0].Endpoint)
+	assert.Equal(t, primitive.FailureCodeIndexNotAvailable, cloned.FailureReasons[0].Code)
+	assert.Equal(t, net.IP{0x06}, cloned.FailureReasons[1].Endpoint)
+	assert.Equal(t, primitive.FailureCodeKeyspaceNotFound, cloned.FailureReasons[1].Code)
+	assert.Equal(t, primitive.WriteTypeCdc, cloned.WriteType)
+}
+
+func TestFunctionFailure_Clone(t *testing.T) {
+	msg := &FunctionFailure{
+		ErrorMessage: "msg",
+		Keyspace:     "ks1",
+		Function:     "f1",
+		Arguments:    []string{"arg1", "arg2"},
+	}
+	cloned := msg.Clone().(*FunctionFailure)
+	assert.Equal(t, msg, cloned)
+	cloned.ErrorMessage = "alt msg"
+	cloned.Keyspace = "ks2"
+	cloned.Function = "f2"
+	cloned.Arguments = []string{"arg3"}
+	assert.NotEqual(t, msg, cloned)
+	assert.Equal(t, "msg", msg.ErrorMessage)
+	assert.Equal(t, "ks1", msg.Keyspace)
+	assert.Equal(t, "f1", msg.Function)
+	assert.Equal(t, []string{"arg1", "arg2"}, msg.Arguments)
+	assert.Equal(t, "alt msg", cloned.ErrorMessage)
+	assert.Equal(t, "ks2", cloned.Keyspace)
+	assert.Equal(t, "f2", cloned.Function)
+	assert.Equal(t, []string{"arg3"}, cloned.Arguments)
+}
+
+func TestUnprepared_Clone(t *testing.T) {
+	msg := &Unprepared{
+		ErrorMessage: "msg",
+		Id:           []byte{0x01},
+	}
+	cloned := msg.Clone().(*Unprepared)
+	assert.Equal(t, msg, cloned)
+	cloned.ErrorMessage = "alt msg"
+	cloned.Id = []byte{0x02, 0x03}
+	assert.NotEqual(t, msg, cloned)
+	assert.Equal(t, "msg", msg.ErrorMessage)
+	assert.Equal(t, []byte{0x01}, msg.Id)
+	assert.Equal(t, "alt msg", cloned.ErrorMessage)
+	assert.Equal(t, []byte{0x02, 0x03}, cloned.Id)
+}
+
+func TestAlreadyExists_Clone(t *testing.T) {
+	msg := &AlreadyExists{
+		ErrorMessage: "msg",
+		Keyspace:     "ks1",
+		Table:        "table1",
+	}
+	cloned := msg.Clone().(*AlreadyExists)
+	assert.Equal(t, msg, cloned)
+	cloned.ErrorMessage = "alt msg"
+	cloned.Keyspace = "ks2"
+	cloned.Table = "table2"
+	assert.NotEqual(t, msg, cloned)
+	assert.Equal(t, "msg", msg.ErrorMessage)
+	assert.Equal(t, "ks1", msg.Keyspace)
+	assert.Equal(t, "table1", msg.Table)
+	assert.Equal(t, "alt msg", cloned.ErrorMessage)
+	assert.Equal(t, "ks2", cloned.Keyspace)
+	assert.Equal(t, "table2", cloned.Table)
+}
+
 func TestErrorCodec_Encode(test *testing.T) {
 	codec := &errorCodec{}
 	// errors encoded the same in all versions

--- a/message/event.go
+++ b/message/event.go
@@ -52,6 +52,16 @@ func (m *SchemaChangeEvent) GetOpCode() primitive.OpCode {
 	return primitive.OpCodeEvent
 }
 
+func (m *SchemaChangeEvent) Clone() Message {
+	return &SchemaChangeEvent{
+		ChangeType: m.ChangeType,
+		Target:     m.Target,
+		Keyspace:   m.Keyspace,
+		Object:     m.Object,
+		Arguments:  primitive.CloneStringSlice(m.Arguments),
+	}
+}
+
 func (m *SchemaChangeEvent) GetEventType() primitive.EventType {
 	return primitive.EventTypeSchemaChange
 }
@@ -80,6 +90,13 @@ func (m *StatusChangeEvent) GetOpCode() primitive.OpCode {
 	return primitive.OpCodeEvent
 }
 
+func (m *StatusChangeEvent) Clone() Message {
+	return &StatusChangeEvent{
+		ChangeType: m.ChangeType,
+		Address:    primitive.CloneInet(m.Address),
+	}
+}
+
 func (m *StatusChangeEvent) GetEventType() primitive.EventType {
 	return primitive.EventTypeStatusChange
 }
@@ -103,6 +120,13 @@ func (m *TopologyChangeEvent) IsResponse() bool {
 
 func (m *TopologyChangeEvent) GetOpCode() primitive.OpCode {
 	return primitive.OpCodeEvent
+}
+
+func (m *TopologyChangeEvent) Clone() Message {
+	return &TopologyChangeEvent{
+		ChangeType: m.ChangeType,
+		Address:    primitive.CloneInet(m.Address),
+	}
 }
 
 func (m *TopologyChangeEvent) GetEventType() primitive.EventType {

--- a/message/event_test.go
+++ b/message/event_test.go
@@ -23,6 +23,91 @@ import (
 	"testing"
 )
 
+func TestSchemaChangeEvent_Clone(t *testing.T) {
+	msg := &SchemaChangeEvent{
+		ChangeType: primitive.SchemaChangeTypeCreated,
+		Target:     primitive.SchemaChangeTargetAggregate,
+		Keyspace:   "ks1",
+		Object:     "aggregate",
+		Arguments:  []string{"arg1"},
+	}
+
+	cloned := msg.Clone().(*SchemaChangeEvent)
+	assert.Equal(t, msg, cloned)
+
+	cloned.ChangeType = primitive.SchemaChangeTypeDropped
+	cloned.Target = primitive.SchemaChangeTargetFunction
+	cloned.Keyspace = "ks2"
+	cloned.Object = "function"
+	cloned.Arguments = []string{"arg2"}
+
+	assert.Equal(t, primitive.SchemaChangeTypeCreated, msg.ChangeType)
+	assert.Equal(t, primitive.SchemaChangeTargetAggregate, msg.Target)
+	assert.Equal(t, "ks1", msg.Keyspace)
+	assert.Equal(t, "aggregate", msg.Object)
+	assert.Equal(t, []string{"arg1"}, msg.Arguments)
+
+	assert.Equal(t, primitive.SchemaChangeTypeDropped, cloned.ChangeType)
+	assert.Equal(t, primitive.SchemaChangeTargetFunction, cloned.Target)
+	assert.Equal(t, "ks2", cloned.Keyspace)
+	assert.Equal(t, "function", cloned.Object)
+	assert.Equal(t, []string{"arg2"}, cloned.Arguments)
+}
+
+func TestStatusChangeEvent_Clone(t *testing.T) {
+	msg := &StatusChangeEvent{
+		ChangeType: primitive.StatusChangeTypeDown,
+		Address:    &primitive.Inet{
+			Addr: net.IP{0x01},
+			Port: 80,
+		},
+	}
+
+	cloned := msg.Clone().(*StatusChangeEvent)
+	assert.Equal(t, msg, cloned)
+
+	cloned.ChangeType = primitive.StatusChangeTypeUp
+	cloned.Address = &primitive.Inet{
+		Addr: net.IP{0x02},
+		Port: 801,
+	}
+
+	assert.Equal(t, primitive.StatusChangeTypeDown, msg.ChangeType)
+	assert.Equal(t, net.IP{0x01}, msg.Address.Addr)
+	assert.EqualValues(t, 80, msg.Address.Port)
+
+	assert.Equal(t, primitive.StatusChangeTypeUp, cloned.ChangeType)
+	assert.Equal(t, net.IP{0x02}, cloned.Address.Addr)
+	assert.EqualValues(t, 801, cloned.Address.Port)
+}
+
+func TestTopologyChangeEvent_Clone(t *testing.T) {
+	msg := &TopologyChangeEvent{
+		ChangeType: primitive.TopologyChangeTypeNewNode,
+		Address:    &primitive.Inet{
+			Addr: net.IP{0x01},
+			Port: 80,
+		},
+	}
+
+	cloned := msg.Clone().(*TopologyChangeEvent)
+	assert.Equal(t, msg, cloned)
+
+	cloned.ChangeType = primitive.TopologyChangeTypeRemovedNode
+	cloned.Address = &primitive.Inet{
+		Addr: net.IP{0x02},
+		Port: 801,
+	}
+
+	assert.Equal(t, primitive.TopologyChangeTypeNewNode, msg.ChangeType)
+	assert.Equal(t, net.IP{0x01}, msg.Address.Addr)
+	assert.EqualValues(t, 80, msg.Address.Port)
+
+	assert.Equal(t, primitive.TopologyChangeTypeRemovedNode, cloned.ChangeType)
+	assert.Equal(t, net.IP{0x02}, cloned.Address.Addr)
+	assert.EqualValues(t, 801, cloned.Address.Port)
+}
+
 func TestEventCodec_Encode(test *testing.T) {
 	codec := &eventCodec{}
 	// version = 2

--- a/message/execute.go
+++ b/message/execute.go
@@ -38,6 +38,14 @@ func (m *Execute) GetOpCode() primitive.OpCode {
 	return primitive.OpCodeExecute
 }
 
+func (m *Execute) Clone() Message {
+	return &Execute{
+		QueryId:          primitive.CloneByteSlice(m.QueryId),
+		ResultMetadataId: primitive.CloneByteSlice(m.ResultMetadataId),
+		Options:          m.Options.Clone(),
+	}
+}
+
 func (m *Execute) String() string {
 	return "EXECUTE " + hex.EncodeToString(m.QueryId)
 }

--- a/message/execute_test.go
+++ b/message/execute_test.go
@@ -22,6 +22,122 @@ import (
 	"testing"
 )
 
+func TestExecute_Clone(t *testing.T) {
+	msg := &Execute{
+		QueryId:          []byte{0x01},
+		ResultMetadataId: []byte{0x02},
+		Options:          &QueryOptions{
+			Consistency:             primitive.ConsistencyLevelAll,
+			PositionalValues:        []*primitive.Value{
+				&primitive.Value{
+					Type:     primitive.ValueTypeRegular,
+					Contents: []byte{0x11},
+				},
+			},
+			NamedValues:             map[string]*primitive.Value{
+				"1": &primitive.Value{
+					Type:     primitive.ValueTypeUnset,
+					Contents: []byte{0x21},
+				},
+			},
+			SkipMetadata:            false,
+			PageSize:                5,
+			PageSizeInBytes:         false,
+			PagingState:             []byte{0x33},
+			SerialConsistency:       &primitive.NillableConsistencyLevel{
+				Value: primitive.ConsistencyLevelLocalSerial},
+			DefaultTimestamp:        &primitive.NillableInt64{
+				Value: 1,
+			},
+			Keyspace:                "ks1",
+			NowInSeconds:            &primitive.NillableInt32{
+				Value: 3,
+			},
+			ContinuousPagingOptions: &ContinuousPagingOptions{
+				MaxPages:       5,
+				PagesPerSecond: 2,
+				NextPages:      3,
+			},
+		},
+	}
+
+	cloned := msg.Clone().(*Execute)
+	assert.Equal(t, msg, cloned)
+
+	cloned.QueryId = []byte{0x41}
+	cloned.ResultMetadataId = []byte{0x52}
+	cloned.Options = &QueryOptions{
+		Consistency:             primitive.ConsistencyLevelLocalOne,
+		PositionalValues:        []*primitive.Value{
+			&primitive.Value{
+				Type:     primitive.ValueTypeUnset,
+				Contents: []byte{0x21},
+			},
+		},
+		NamedValues:             map[string]*primitive.Value{
+			"1": &primitive.Value{
+				Type:     primitive.ValueTypeNull,
+				Contents: []byte{0x31},
+			},
+		},
+		SkipMetadata:            true,
+		PageSize:                4,
+		PageSizeInBytes:         true,
+		PagingState:             []byte{0x23},
+		SerialConsistency:       nil,
+		DefaultTimestamp:        &primitive.NillableInt64{
+			Value: 3,
+		},
+		Keyspace:                "ks2",
+		NowInSeconds:            nil,
+		ContinuousPagingOptions: &ContinuousPagingOptions{
+			MaxPages:       6,
+			PagesPerSecond: 3,
+			NextPages:      4,
+		},
+	}
+
+	assert.Equal(t, []byte{0x01}, msg.QueryId)
+	assert.Equal(t, []byte{0x02}, msg.ResultMetadataId)
+	assert.Equal(t, primitive.ConsistencyLevelAll, msg.Options.Consistency)
+	assert.Equal(t, primitive.ValueTypeRegular, msg.Options.PositionalValues[0].Type)
+	assert.Equal(t, []byte{0x11}, msg.Options.PositionalValues[0].Contents)
+	assert.Equal(t, primitive.ValueTypeUnset, msg.Options.NamedValues["1"].Type)
+	assert.Equal(t, []byte{0x21}, msg.Options.NamedValues["1"].Contents)
+	assert.False(t, msg.Options.SkipMetadata)
+	assert.EqualValues(t, 5, msg.Options.PageSize)
+	assert.False(t, msg.Options.PageSizeInBytes)
+	assert.Equal(t, []byte{0x33}, msg.Options.PagingState)
+	assert.Equal(t, primitive.ConsistencyLevelLocalSerial, msg.Options.SerialConsistency.Value)
+	assert.EqualValues(t, 1, msg.Options.DefaultTimestamp.Value)
+	assert.Equal(t, "ks1", msg.Options.Keyspace)
+	assert.EqualValues(t, 3, msg.Options.NowInSeconds.Value)
+	assert.EqualValues(t, 5, msg.Options.ContinuousPagingOptions.MaxPages)
+	assert.EqualValues(t, 2, msg.Options.ContinuousPagingOptions.PagesPerSecond)
+	assert.EqualValues(t, 3, msg.Options.ContinuousPagingOptions.NextPages)
+
+	assert.NotEqual(t, msg, cloned)
+
+	assert.Equal(t, []byte{0x41}, cloned.QueryId)
+	assert.Equal(t, []byte{0x52}, cloned.ResultMetadataId)
+	assert.Equal(t, primitive.ConsistencyLevelLocalOne, cloned.Options.Consistency)
+	assert.Equal(t, primitive.ValueTypeUnset, cloned.Options.PositionalValues[0].Type)
+	assert.Equal(t, []byte{0x21}, cloned.Options.PositionalValues[0].Contents)
+	assert.Equal(t, primitive.ValueTypeNull, cloned.Options.NamedValues["1"].Type)
+	assert.Equal(t, []byte{0x31}, cloned.Options.NamedValues["1"].Contents)
+	assert.True(t, cloned.Options.SkipMetadata)
+	assert.EqualValues(t, 4, cloned.Options.PageSize)
+	assert.True(t, cloned.Options.PageSizeInBytes)
+	assert.Equal(t, []byte{0x23}, cloned.Options.PagingState)
+	assert.Nil(t, cloned.Options.SerialConsistency)
+	assert.EqualValues(t, 3, cloned.Options.DefaultTimestamp.Value)
+	assert.Equal(t, "ks2", cloned.Options.Keyspace)
+	assert.Nil(t, cloned.Options.NowInSeconds)
+	assert.EqualValues(t, 6, cloned.Options.ContinuousPagingOptions.MaxPages)
+	assert.EqualValues(t, 3, cloned.Options.ContinuousPagingOptions.PagesPerSecond)
+	assert.EqualValues(t, 4, cloned.Options.ContinuousPagingOptions.NextPages)
+}
+
 func TestExecuteCodec_Encode(t *testing.T) {
 	codec := &executeCodec{}
 	// tests for versions < 4

--- a/message/message.go
+++ b/message/message.go
@@ -21,7 +21,8 @@ import (
 
 type Message interface {
 	IsResponse() bool
-	GetOpCode() primitive.OpCode
+	GetOpCode()  primitive.OpCode
+	Clone()      Message
 }
 
 type Encoder interface {

--- a/message/options.go
+++ b/message/options.go
@@ -32,6 +32,10 @@ func (m *Options) GetOpCode() primitive.OpCode {
 	return primitive.OpCodeOptions
 }
 
+func (m *Options) Clone() Message {
+	return &Options{}
+}
+
 func (m *Options) String() string {
 	return "OPTIONS"
 }

--- a/message/prepare.go
+++ b/message/prepare.go
@@ -35,6 +35,11 @@ func (m *Prepare) GetOpCode() primitive.OpCode {
 	return primitive.OpCodePrepare
 }
 
+func (m *Prepare) Clone() Message {
+	newObj := *m
+	return &newObj
+}
+
 func (m *Prepare) String() string {
 	return fmt.Sprintf("PREPARE (%v, %v)", m.Query, m.Keyspace)
 }

--- a/message/prepare_test.go
+++ b/message/prepare_test.go
@@ -22,6 +22,27 @@ import (
 	"testing"
 )
 
+func TestPrepare_Clone(t *testing.T) {
+	msg := &Prepare{
+		Query:    "query",
+		Keyspace: "ks1",
+	}
+
+	cloned := msg.Clone().(*Prepare)
+	assert.Equal(t, msg, cloned)
+
+	cloned.Query = "query2"
+	cloned.Keyspace = "ks2"
+
+	assert.NotEqual(t, msg, cloned)
+
+	assert.Equal(t, "query", msg.Query)
+	assert.Equal(t, "ks1", msg.Keyspace)
+
+	assert.Equal(t, "query2", cloned.Query)
+	assert.Equal(t, "ks2", cloned.Keyspace)
+}
+
 func TestPrepareCodec_Encode(t *testing.T) {
 	codec := &prepareCodec{}
 	// versions <= 4 + DSE v1

--- a/message/query.go
+++ b/message/query.go
@@ -38,6 +38,20 @@ func (q *Query) GetOpCode() primitive.OpCode {
 	return primitive.OpCodeQuery
 }
 
+func (q *Query) Clone() Message {
+	var newQueryOptions *QueryOptions
+	if q.Options != nil {
+		newQueryOptions = q.Options.Clone()
+	} else {
+		newQueryOptions = nil
+	}
+
+	return &Query{
+		Query:   q.Query,
+		Options: newQueryOptions,
+	}
+}
+
 type queryCodec struct{}
 
 func (c *queryCodec) Encode(msg Message, dest io.Writer, version primitive.ProtocolVersion) error {

--- a/message/query_options.go
+++ b/message/query_options.go
@@ -66,6 +66,23 @@ type QueryOptions struct {
 	ContinuousPagingOptions *ContinuousPagingOptions
 }
 
+func (o *QueryOptions) Clone() *QueryOptions {
+	return &QueryOptions{
+		Consistency:             o.Consistency,
+		PositionalValues:        CloneValuesSlice(o.PositionalValues),
+		NamedValues:             CloneValuesMap(o.NamedValues),
+		SkipMetadata:            o.SkipMetadata,
+		PageSize:                o.PageSize,
+		PageSizeInBytes:         o.PageSizeInBytes,
+		PagingState:             primitive.CloneByteSlice(o.PagingState),
+		SerialConsistency:       primitive.CloneNillableConsistencyLevel(o.SerialConsistency),
+		DefaultTimestamp:        primitive.CloneNillableInt64(o.DefaultTimestamp),
+		Keyspace:                o.Keyspace,
+		NowInSeconds:            primitive.CloneNillableInt32(o.NowInSeconds),
+		ContinuousPagingOptions: CloneContinuousPagingOptions(o.ContinuousPagingOptions),
+	}
+}
+
 func (o *QueryOptions) String() string {
 	return fmt.Sprintf(
 		"[cl=%v, positionalVals=%v, namedVals=%v, skip=%v, psize=%v, state=%v, serialCl=%v]",
@@ -321,4 +338,32 @@ func DecodeQueryOptions(source io.Reader, version primitive.ProtocolVersion) (op
 		}
 	}
 	return options, nil
+}
+
+func CloneValuesSlice(o []*primitive.Value) []*primitive.Value {
+	var newValues []*primitive.Value
+	if o != nil {
+		newValues = make([]*primitive.Value, len(o))
+		for idx, v := range o {
+			newValues[idx] = v.Clone()
+		}
+	} else {
+		newValues = nil
+	}
+
+	return newValues
+}
+
+func CloneValuesMap(o map[string]*primitive.Value) map[string]*primitive.Value {
+	var newValues map[string]*primitive.Value
+	if o != nil {
+		newValues = make(map[string]*primitive.Value)
+		for key, v := range o {
+			newValues[key] = v.Clone()
+		}
+	} else {
+		newValues = nil
+	}
+
+	return newValues
 }

--- a/message/query_test.go
+++ b/message/query_test.go
@@ -22,6 +22,118 @@ import (
 	"testing"
 )
 
+func TestQuery_Clone(t *testing.T) {
+	msg := &Query{
+		Query: "query",
+		Options: &QueryOptions{
+			Consistency: primitive.ConsistencyLevelAll,
+			PositionalValues: []*primitive.Value{
+				&primitive.Value{
+					Type:     primitive.ValueTypeRegular,
+					Contents: []byte{0x11},
+				},
+			},
+			NamedValues: map[string]*primitive.Value{
+				"1": &primitive.Value{
+					Type:     primitive.ValueTypeUnset,
+					Contents: []byte{0x21},
+				},
+			},
+			SkipMetadata:    false,
+			PageSize:        5,
+			PageSizeInBytes: false,
+			PagingState:     []byte{0x33},
+			SerialConsistency: &primitive.NillableConsistencyLevel{
+				Value: primitive.ConsistencyLevelLocalSerial},
+			DefaultTimestamp: &primitive.NillableInt64{
+				Value: 1,
+			},
+			Keyspace: "ks1",
+			NowInSeconds: &primitive.NillableInt32{
+				Value: 3,
+			},
+			ContinuousPagingOptions: &ContinuousPagingOptions{
+				MaxPages:       5,
+				PagesPerSecond: 2,
+				NextPages:      3,
+			},
+		},
+	}
+
+	cloned := msg.Clone().(*Query)
+	assert.Equal(t, msg, cloned)
+
+	cloned.Query = "query 2"
+	cloned.Options = &QueryOptions{
+		Consistency:             primitive.ConsistencyLevelLocalOne,
+		PositionalValues:        []*primitive.Value{
+			&primitive.Value{
+				Type:     primitive.ValueTypeUnset,
+				Contents: []byte{0x21},
+			},
+		},
+		NamedValues:             map[string]*primitive.Value{
+			"1": &primitive.Value{
+				Type:     primitive.ValueTypeNull,
+				Contents: []byte{0x31},
+			},
+		},
+		SkipMetadata:            true,
+		PageSize:                4,
+		PageSizeInBytes:         true,
+		PagingState:             []byte{0x23},
+		SerialConsistency:       nil,
+		DefaultTimestamp:        &primitive.NillableInt64{
+			Value: 3,
+		},
+		Keyspace:                "ks2",
+		NowInSeconds:            nil,
+		ContinuousPagingOptions: &ContinuousPagingOptions{
+			MaxPages:       6,
+			PagesPerSecond: 3,
+			NextPages:      4,
+		},
+	}
+
+	assert.Equal(t, "query", msg.Query)
+	assert.Equal(t, primitive.ConsistencyLevelAll, msg.Options.Consistency)
+	assert.Equal(t, primitive.ValueTypeRegular, msg.Options.PositionalValues[0].Type)
+	assert.Equal(t, []byte{0x11}, msg.Options.PositionalValues[0].Contents)
+	assert.Equal(t, primitive.ValueTypeUnset, msg.Options.NamedValues["1"].Type)
+	assert.Equal(t, []byte{0x21}, msg.Options.NamedValues["1"].Contents)
+	assert.False(t, msg.Options.SkipMetadata)
+	assert.EqualValues(t, 5, msg.Options.PageSize)
+	assert.False(t, msg.Options.PageSizeInBytes)
+	assert.Equal(t, []byte{0x33}, msg.Options.PagingState)
+	assert.Equal(t, primitive.ConsistencyLevelLocalSerial, msg.Options.SerialConsistency.Value)
+	assert.EqualValues(t, 1, msg.Options.DefaultTimestamp.Value)
+	assert.Equal(t, "ks1", msg.Options.Keyspace)
+	assert.EqualValues(t, 3, msg.Options.NowInSeconds.Value)
+	assert.EqualValues(t, 5, msg.Options.ContinuousPagingOptions.MaxPages)
+	assert.EqualValues(t, 2, msg.Options.ContinuousPagingOptions.PagesPerSecond)
+	assert.EqualValues(t, 3, msg.Options.ContinuousPagingOptions.NextPages)
+
+	assert.NotEqual(t, msg, cloned)
+
+	assert.Equal(t, "query 2", cloned.Query)
+	assert.Equal(t, primitive.ConsistencyLevelLocalOne, cloned.Options.Consistency)
+	assert.Equal(t, primitive.ValueTypeUnset, cloned.Options.PositionalValues[0].Type)
+	assert.Equal(t, []byte{0x21}, cloned.Options.PositionalValues[0].Contents)
+	assert.Equal(t, primitive.ValueTypeNull, cloned.Options.NamedValues["1"].Type)
+	assert.Equal(t, []byte{0x31}, cloned.Options.NamedValues["1"].Contents)
+	assert.True(t, cloned.Options.SkipMetadata)
+	assert.EqualValues(t, 4, cloned.Options.PageSize)
+	assert.True(t, cloned.Options.PageSizeInBytes)
+	assert.Equal(t, []byte{0x23}, cloned.Options.PagingState)
+	assert.Nil(t, cloned.Options.SerialConsistency)
+	assert.EqualValues(t, 3, cloned.Options.DefaultTimestamp.Value)
+	assert.Equal(t, "ks2", cloned.Options.Keyspace)
+	assert.Nil(t, cloned.Options.NowInSeconds)
+	assert.EqualValues(t, 6, cloned.Options.ContinuousPagingOptions.MaxPages)
+	assert.EqualValues(t, 3, cloned.Options.ContinuousPagingOptions.PagesPerSecond)
+	assert.EqualValues(t, 4, cloned.Options.ContinuousPagingOptions.NextPages)
+}
+
 func TestQueryCodec_Encode(t *testing.T) {
 	codec := &queryCodec{}
 	// tests for version 2

--- a/message/ready.go
+++ b/message/ready.go
@@ -32,6 +32,10 @@ func (m *Ready) GetOpCode() primitive.OpCode {
 	return primitive.OpCodeReady
 }
 
+func (m *Ready) Clone() Message {
+	return &Ready{}
+}
+
 func (m *Ready) String() string {
 	return "READY"
 }

--- a/message/register.go
+++ b/message/register.go
@@ -33,6 +33,20 @@ func (m *Register) GetOpCode() primitive.OpCode {
 	return primitive.OpCodeRegister
 }
 
+func (m *Register) Clone() Message {
+	var newEventTypes []primitive.EventType
+	if m.EventTypes != nil {
+		newEventTypes = make([]primitive.EventType, len(m.EventTypes))
+		copy(newEventTypes, m.EventTypes)
+	} else {
+		newEventTypes = nil
+	}
+	
+	return &Register{
+		EventTypes: newEventTypes,
+	}
+}
+
 func (m *Register) String() string {
 	return fmt.Sprint("REGISTER ", m.EventTypes)
 }

--- a/message/register_test.go
+++ b/message/register_test.go
@@ -22,6 +22,23 @@ import (
 	"testing"
 )
 
+func TestRegister_Clone(t *testing.T) {
+	msg := &Register{
+		EventTypes: []primitive.EventType{primitive.EventTypeSchemaChange},
+	}
+
+	cloned := msg.Clone().(*Register)
+	assert.Equal(t, msg, cloned)
+
+	cloned.EventTypes = []primitive.EventType{primitive.EventTypeSchemaChange, primitive.EventTypeStatusChange}
+
+	assert.NotEqual(t, msg, cloned)
+
+	assert.Equal(t, []primitive.EventType{primitive.EventTypeSchemaChange}, msg.EventTypes)
+
+	assert.Equal(t, []primitive.EventType{primitive.EventTypeSchemaChange, primitive.EventTypeStatusChange}, cloned.EventTypes)
+}
+
 func TestRegisterCodec_Encode(t *testing.T) {
 	codec := &registerCodec{}
 	for _, version := range primitive.AllProtocolVersions() {

--- a/message/result.go
+++ b/message/result.go
@@ -548,7 +548,11 @@ func hasResultMetadataId(version primitive.ProtocolVersion) bool {
 }
 
 func cloneRowSet(o RowSet) RowSet {
-	newRowSet := RowSet{}
+	if o == nil {
+		return nil
+	}
+
+	newRowSet := make(RowSet, len(o))
 	for idx, v := range o {
 		newRowSet[idx] = cloneRow(v)
 	}
@@ -557,7 +561,11 @@ func cloneRowSet(o RowSet) RowSet {
 }
 
 func cloneRow(o Row) Row {
-	newRow := Row{}
+	if o == nil {
+		return nil
+	}
+
+	newRow := make(Row, len(o))
 	for idx, v := range o {
 		newRow[idx] = primitive.CloneByteSlice(v)
 	}

--- a/message/result.go
+++ b/message/result.go
@@ -42,6 +42,10 @@ func (m *VoidResult) GetResultType() primitive.ResultType {
 	return primitive.ResultTypeVoid
 }
 
+func (m *VoidResult) Clone() Message {
+	return &VoidResult{}
+}
+
 func (m *VoidResult) String() string {
 	return "RESULT VOID"
 }
@@ -54,6 +58,12 @@ type SetKeyspaceResult struct {
 
 func (m *SetKeyspaceResult) IsResponse() bool {
 	return true
+}
+
+func (m *SetKeyspaceResult) Clone() Message {
+	return &SetKeyspaceResult{
+		Keyspace: m.Keyspace,
+	}
 }
 
 func (m *SetKeyspaceResult) GetOpCode() primitive.OpCode {
@@ -95,6 +105,16 @@ func (m *SchemaChangeResult) GetOpCode() primitive.OpCode {
 	return primitive.OpCodeResult
 }
 
+func (m *SchemaChangeResult) Clone() Message {
+	return &SchemaChangeResult{
+		ChangeType: m.ChangeType,
+		Target:     m.Target,
+		Keyspace:   m.Keyspace,
+		Object:     m.Object,
+		Arguments:  primitive.CloneStringSlice(m.Arguments),
+	}
+}
+
 func (m *SchemaChangeResult) GetResultType() primitive.ResultType {
 	return primitive.ResultTypeSchemaChange
 }
@@ -122,6 +142,15 @@ type PreparedResult struct {
 
 func (m *PreparedResult) IsResponse() bool {
 	return true
+}
+
+func (m *PreparedResult) Clone() Message {
+	return &PreparedResult{
+		PreparedQueryId:   primitive.CloneByteSlice(m.PreparedQueryId),
+		ResultMetadataId:  primitive.CloneByteSlice(m.ResultMetadataId),
+		VariablesMetadata: cloneVariablesMetadata(m.VariablesMetadata),
+		ResultMetadata:    cloneRowsMetadata(m.ResultMetadata),
+	}
 }
 
 func (m *PreparedResult) GetOpCode() primitive.OpCode {
@@ -155,6 +184,13 @@ func (m *RowsResult) IsResponse() bool {
 
 func (m *RowsResult) GetOpCode() primitive.OpCode {
 	return primitive.OpCodeResult
+}
+
+func (m *RowsResult) Clone() Message {
+	return &RowsResult{
+		Metadata: cloneRowsMetadata(m.Metadata),
+		Data:     cloneRowSet(m.Data),
+	}
 }
 
 func (m *RowsResult) GetResultType() primitive.ResultType {
@@ -509,4 +545,22 @@ func (c *resultCodec) GetOpCode() primitive.OpCode {
 func hasResultMetadataId(version primitive.ProtocolVersion) bool {
 	return version >= primitive.ProtocolVersion5 &&
 		version != primitive.ProtocolVersionDse1
+}
+
+func cloneRowSet(o RowSet) RowSet {
+	newRowSet := RowSet{}
+	for idx, v := range o {
+		newRowSet[idx] = cloneRow(v)
+	}
+
+	return newRowSet
+}
+
+func cloneRow(o Row) Row {
+	newRow := Row{}
+	for idx, v := range o {
+		newRow[idx] = primitive.CloneByteSlice(v)
+	}
+
+	return newRow
 }

--- a/message/result_metadata.go
+++ b/message/result_metadata.go
@@ -380,3 +380,63 @@ func haveSameTable(cols []*ColumnMetadata) bool {
 	}
 	return true
 }
+
+func cloneColumnMetadata(cm *ColumnMetadata) *ColumnMetadata {
+	if cm == nil {
+		return nil
+	}
+
+	return &ColumnMetadata{
+		Keyspace: cm.Keyspace,
+		Table:    cm.Table,
+		Name:     cm.Name,
+		Index:    cm.Index,
+		Type:     cm.Type.Clone(),
+	}
+}
+
+func cloneVariablesMetadata(vm *VariablesMetadata) *VariablesMetadata {
+	var newPkIndices []uint16
+	if vm.PkIndices != nil {
+		newPkIndices = make([]uint16, len(vm.PkIndices))
+		copy(newPkIndices, vm.PkIndices)
+	} else {
+		newPkIndices = nil
+	}
+
+	var newColumnMetadata []*ColumnMetadata
+	if vm.Columns != nil {
+		newColumnMetadata = make([]*ColumnMetadata, len(vm.Columns))
+		for idx, cm := range vm.Columns {
+			newColumnMetadata[idx] = cloneColumnMetadata(cm)
+		}
+	} else {
+		newColumnMetadata = nil
+	}
+
+	return &VariablesMetadata{
+		PkIndices: newPkIndices,
+		Columns:   newColumnMetadata,
+	}
+}
+
+func cloneRowsMetadata(rm *RowsMetadata) *RowsMetadata {
+	var newColumnMetadata []*ColumnMetadata
+	if rm.Columns != nil {
+		newColumnMetadata = make([]*ColumnMetadata, len(rm.Columns))
+		for idx, cm := range rm.Columns {
+			newColumnMetadata[idx] = cloneColumnMetadata(cm)
+		}
+	} else {
+		newColumnMetadata = nil
+	}
+
+	return &RowsMetadata{
+		ColumnCount:          rm.ColumnCount,
+		PagingState:          primitive.CloneByteSlice(rm.PagingState),
+		NewResultMetadataId:  primitive.CloneByteSlice(rm.NewResultMetadataId),
+		ContinuousPageNumber: rm.ContinuousPageNumber,
+		LastContinuousPage:   rm.LastContinuousPage,
+		Columns:              newColumnMetadata,
+	}
+}

--- a/message/result_other_test.go
+++ b/message/result_other_test.go
@@ -21,6 +21,22 @@ import (
 	"testing"
 )
 
+func TestSetKeyspaceResult_Clone(t *testing.T) {
+	msg := &SetKeyspaceResult{
+		Keyspace: "ks1",
+	}
+
+	cloned := msg.Clone().(*SetKeyspaceResult)
+	assert.Equal(t, msg, cloned)
+
+	cloned.Keyspace = "ks2"
+
+	assert.NotEqual(t, msg, cloned)
+
+	assert.Equal(t, "ks1", msg.Keyspace)
+	assert.Equal(t, "ks2", cloned.Keyspace)
+}
+
 func TestResultCodec_Encode_Other(test *testing.T) {
 	codec := &resultCodec{}
 	for _, version := range primitive.AllProtocolVersions() {

--- a/message/result_prepared_test.go
+++ b/message/result_prepared_test.go
@@ -22,6 +22,140 @@ import (
 	"testing"
 )
 
+func TestPreparedResult_Clone(t *testing.T) {
+	msg := &PreparedResult{
+		PreparedQueryId:   []byte{0x12},
+		ResultMetadataId:  []byte{0x23},
+		VariablesMetadata: &VariablesMetadata{
+			PkIndices: []uint16{0},
+			Columns:   []*ColumnMetadata{
+				{
+					Keyspace: "ks1",
+					Table:    "tb1",
+					Name:     "c1",
+					Index:    0,
+					Type:     datatype.Ascii,
+				},
+			},
+		},
+		ResultMetadata:    &RowsMetadata{
+			ColumnCount:          1,
+			PagingState:          nil,
+			NewResultMetadataId:  nil,
+			ContinuousPageNumber: 1,
+			LastContinuousPage:   false,
+			Columns:              []*ColumnMetadata{
+				{
+					Keyspace: "ks1",
+					Table:    "tb1",
+					Name:     "c1",
+					Index:    0,
+					Type:     datatype.Ascii,
+				},
+			},
+		},
+	}
+
+	cloned := msg.Clone().(*PreparedResult)
+	assert.Equal(t, msg, cloned)
+
+	cloned.PreparedQueryId = []byte{0x42}
+	cloned.ResultMetadataId = []byte{0x51}
+	cloned.VariablesMetadata = &VariablesMetadata{
+		PkIndices: []uint16{1},
+		Columns:   []*ColumnMetadata{
+			{
+				Keyspace: "ks2",
+				Table:    "tb2",
+				Name:     "c2",
+				Index:    0,
+				Type:     datatype.Float,
+			},
+			{
+				Keyspace: "ks2",
+				Table:    "tb2",
+				Name:     "c3",
+				Index:    1,
+				Type:     datatype.Uuid,
+			},
+		},
+	}
+	cloned.ResultMetadata = &RowsMetadata{
+		ColumnCount:          1,
+		PagingState:          []byte{0x22},
+		NewResultMetadataId:  []byte{0x33},
+		ContinuousPageNumber: 3,
+		LastContinuousPage:   true,
+		Columns:              []*ColumnMetadata{
+			{
+				Keyspace: "ks2",
+				Table:    "tb2",
+				Name:     "c2",
+				Index:    0,
+				Type:     datatype.Float,
+			},
+			{
+				Keyspace: "ks2",
+				Table:    "tb2",
+				Name:     "c3",
+				Index:    1,
+				Type:     datatype.Uuid,
+			},
+		},
+	}
+
+	assert.NotEqual(t, msg, cloned)
+	assert.Equal(t, []byte{0x12}, msg.PreparedQueryId)
+	assert.Equal(t, []byte{0x23}, msg.ResultMetadataId)
+	assert.EqualValues(t, 0, msg.VariablesMetadata.PkIndices[0])
+	assert.Equal(t, "ks1", msg.VariablesMetadata.Columns[0].Keyspace)
+	assert.Equal(t, "tb1", msg.VariablesMetadata.Columns[0].Table)
+	assert.Equal(t, "c1", msg.VariablesMetadata.Columns[0].Name)
+	assert.EqualValues(t, 0, msg.VariablesMetadata.Columns[0].Index)
+	assert.Equal(t, datatype.Ascii, msg.VariablesMetadata.Columns[0].Type)
+
+	assert.EqualValues(t, 1, msg.ResultMetadata.ColumnCount)
+	assert.Nil(t, msg.ResultMetadata.PagingState)
+	assert.Nil(t, msg.ResultMetadata.NewResultMetadataId)
+	assert.EqualValues(t, 1, msg.ResultMetadata.ContinuousPageNumber)
+	assert.False(t, msg.ResultMetadata.LastContinuousPage)
+	assert.Equal(t, "ks1", msg.ResultMetadata.Columns[0].Keyspace)
+	assert.Equal(t, "tb1", msg.ResultMetadata.Columns[0].Table)
+	assert.Equal(t, "c1", msg.ResultMetadata.Columns[0].Name)
+	assert.EqualValues(t, 0, msg.ResultMetadata.Columns[0].Index)
+	assert.Equal(t, datatype.Ascii, msg.ResultMetadata.Columns[0].Type)
+
+	assert.Equal(t, []byte{0x42}, cloned.PreparedQueryId)
+	assert.Equal(t, []byte{0x51}, cloned.ResultMetadataId)
+	assert.EqualValues(t, 1, cloned.VariablesMetadata.PkIndices[0])
+	assert.Equal(t, "ks2", cloned.VariablesMetadata.Columns[0].Keyspace)
+	assert.Equal(t, "tb2", cloned.VariablesMetadata.Columns[0].Table)
+	assert.Equal(t, "c2", cloned.VariablesMetadata.Columns[0].Name)
+	assert.EqualValues(t, 0, cloned.VariablesMetadata.Columns[0].Index)
+	assert.Equal(t, datatype.Float, cloned.VariablesMetadata.Columns[0].Type)
+	assert.Equal(t, "ks2", cloned.VariablesMetadata.Columns[1].Keyspace)
+	assert.Equal(t, "tb2", cloned.VariablesMetadata.Columns[1].Table)
+	assert.Equal(t, "c3", cloned.VariablesMetadata.Columns[1].Name)
+	assert.EqualValues(t, 1, cloned.VariablesMetadata.Columns[1].Index)
+	assert.Equal(t, datatype.Uuid, cloned.VariablesMetadata.Columns[1].Type)
+
+	assert.EqualValues(t, 1, cloned.ResultMetadata.ColumnCount)
+	assert.Equal(t, []byte{0x22}, cloned.ResultMetadata.PagingState)
+	assert.Equal(t, []byte{0x33}, cloned.ResultMetadata.NewResultMetadataId)
+	assert.EqualValues(t, 3, cloned.ResultMetadata.ContinuousPageNumber)
+	assert.True(t, cloned.ResultMetadata.LastContinuousPage)
+	assert.Equal(t, "ks2", cloned.ResultMetadata.Columns[0].Keyspace)
+	assert.Equal(t, "tb2", cloned.ResultMetadata.Columns[0].Table)
+	assert.Equal(t, "c2", cloned.ResultMetadata.Columns[0].Name)
+	assert.EqualValues(t, 0, cloned.ResultMetadata.Columns[0].Index)
+	assert.Equal(t, datatype.Float, cloned.ResultMetadata.Columns[0].Type)
+	assert.Equal(t, "ks2", cloned.ResultMetadata.Columns[1].Keyspace)
+	assert.Equal(t, "tb2", cloned.ResultMetadata.Columns[1].Table)
+	assert.Equal(t, "c3", cloned.ResultMetadata.Columns[1].Name)
+	assert.EqualValues(t, 1, cloned.ResultMetadata.Columns[1].Index)
+	assert.Equal(t, datatype.Uuid, cloned.ResultMetadata.Columns[1].Type)
+}
+
 func TestResultCodec_Encode_Prepared(test *testing.T) {
 	codec := &resultCodec{}
 	// versions < 4

--- a/message/result_rows_test.go
+++ b/message/result_rows_test.go
@@ -22,6 +22,98 @@ import (
 	"testing"
 )
 
+func TestRowsResult_Clone(t *testing.T) {
+	msg := &RowsResult{
+		Metadata: &RowsMetadata{
+			ColumnCount:          1,
+			PagingState:          nil,
+			NewResultMetadataId:  nil,
+			ContinuousPageNumber: 1,
+			LastContinuousPage:   false,
+			Columns:              []*ColumnMetadata{
+				{
+					Keyspace: "ks1",
+					Table:    "tb1",
+					Name:     "c1",
+					Index:    0,
+					Type:     datatype.Ascii,
+				},
+			},
+		},
+		Data:     RowSet{
+			{
+				{0x12, 0x23},
+			},
+			{
+				{0x44, 0x55},
+			},
+		},
+	}
+
+	cloned := msg.Clone().(*RowsResult)
+	assert.Equal(t, msg, cloned)
+
+	cloned.Metadata = &RowsMetadata{
+		ColumnCount:          1,
+		PagingState:          []byte{0x22},
+		NewResultMetadataId:  []byte{0x33},
+		ContinuousPageNumber: 3,
+		LastContinuousPage:   true,
+		Columns:              []*ColumnMetadata{
+			{
+				Keyspace: "ks2",
+				Table:    "tb2",
+				Name:     "c2",
+				Index:    0,
+				Type:     datatype.Float,
+			},
+			{
+				Keyspace: "ks2",
+				Table:    "tb2",
+				Name:     "c3",
+				Index:    1,
+				Type:     datatype.Uuid,
+			},
+		},
+	}
+	cloned.Data = RowSet{
+		{
+			{0x52, 0x63},
+		},
+	}
+
+	assert.NotEqual(t, msg, cloned)
+
+	assert.EqualValues(t, 1, msg.Metadata.ColumnCount)
+	assert.Nil(t, msg.Metadata.PagingState)
+	assert.Nil(t, msg.Metadata.NewResultMetadataId)
+	assert.EqualValues(t, 1, msg.Metadata.ContinuousPageNumber)
+	assert.False(t, msg.Metadata.LastContinuousPage)
+	assert.Equal(t, "ks1", msg.Metadata.Columns[0].Keyspace)
+	assert.Equal(t, "tb1", msg.Metadata.Columns[0].Table)
+	assert.Equal(t, "c1", msg.Metadata.Columns[0].Name)
+	assert.EqualValues(t, 0, msg.Metadata.Columns[0].Index)
+	assert.Equal(t, datatype.Ascii, msg.Metadata.Columns[0].Type)
+	assert.Equal(t, RowSet{{{0x12, 0x23}},{{0x44, 0x55}}}, msg.Data)
+
+	assert.EqualValues(t, 1, cloned.Metadata.ColumnCount)
+	assert.Equal(t, []byte{0x22}, cloned.Metadata.PagingState)
+	assert.Equal(t, []byte{0x33}, cloned.Metadata.NewResultMetadataId)
+	assert.EqualValues(t, 3, cloned.Metadata.ContinuousPageNumber)
+	assert.True(t, cloned.Metadata.LastContinuousPage)
+	assert.Equal(t, "ks2", cloned.Metadata.Columns[0].Keyspace)
+	assert.Equal(t, "tb2", cloned.Metadata.Columns[0].Table)
+	assert.Equal(t, "c2", cloned.Metadata.Columns[0].Name)
+	assert.EqualValues(t, 0, cloned.Metadata.Columns[0].Index)
+	assert.Equal(t, datatype.Float, cloned.Metadata.Columns[0].Type)
+	assert.Equal(t, "ks2", cloned.Metadata.Columns[1].Keyspace)
+	assert.Equal(t, "tb2", cloned.Metadata.Columns[1].Table)
+	assert.Equal(t, "c3", cloned.Metadata.Columns[1].Name)
+	assert.EqualValues(t, 1, cloned.Metadata.Columns[1].Index)
+	assert.Equal(t, datatype.Uuid, cloned.Metadata.Columns[1].Type)
+	assert.Equal(t, RowSet{{{0x52, 0x63}}}, cloned.Data)
+}
+
 func TestResultCodec_Encode_Rows(test *testing.T) {
 	row1 := Row{
 		Column{0, 0, 0, 1},    // int = 1

--- a/message/result_schema_change_test.go
+++ b/message/result_schema_change_test.go
@@ -22,6 +22,37 @@ import (
 	"testing"
 )
 
+func TestSchemaChangeResult_Clone(t *testing.T) {
+	msg := &SchemaChangeResult{
+		ChangeType: primitive.SchemaChangeTypeCreated,
+		Target:     primitive.SchemaChangeTargetAggregate,
+		Keyspace:   "ks1",
+		Object:     "aggregate",
+		Arguments:  []string{"arg1"},
+	}
+
+	cloned := msg.Clone().(*SchemaChangeResult)
+	assert.Equal(t, msg, cloned)
+
+	cloned.ChangeType = primitive.SchemaChangeTypeDropped
+	cloned.Target = primitive.SchemaChangeTargetFunction
+	cloned.Keyspace = "ks2"
+	cloned.Object = "function"
+	cloned.Arguments = []string{"arg2"}
+
+	assert.Equal(t, primitive.SchemaChangeTypeCreated, msg.ChangeType)
+	assert.Equal(t, primitive.SchemaChangeTargetAggregate, msg.Target)
+	assert.Equal(t, "ks1", msg.Keyspace)
+	assert.Equal(t, "aggregate", msg.Object)
+	assert.Equal(t, []string{"arg1"}, msg.Arguments)
+
+	assert.Equal(t, primitive.SchemaChangeTypeDropped, cloned.ChangeType)
+	assert.Equal(t, primitive.SchemaChangeTargetFunction, cloned.Target)
+	assert.Equal(t, "ks2", cloned.Keyspace)
+	assert.Equal(t, "function", cloned.Object)
+	assert.Equal(t, []string{"arg2"}, cloned.Arguments)
+}
+
 func TestResultCodec_Encode_SchemaChange(test *testing.T) {
 	codec := &resultCodec{}
 	// version = 2

--- a/message/startup.go
+++ b/message/startup.go
@@ -110,6 +110,12 @@ func (m *Startup) GetOpCode() primitive.OpCode {
 	return primitive.OpCodeStartup
 }
 
+func (m *Startup) Clone() Message {
+	return &Startup{
+		Options: primitive.CloneOptions(m.Options),
+	}
+}
+
 func (m *Startup) String() string {
 	return fmt.Sprint("STARTUP ", m.Options)
 }

--- a/message/startup_test.go
+++ b/message/startup_test.go
@@ -22,6 +22,30 @@ import (
 	"testing"
 )
 
+func TestStartup_Clone(t *testing.T) {
+	msg := &Startup{
+		Options: map[string]string{
+			"opt1": "val1",
+			"opt2": "val2",
+		},
+	}
+
+	cloned := msg.Clone().(*Startup)
+	assert.Equal(t, msg, cloned)
+
+	cloned.Options["opt1"] = "val5"
+	cloned.Options["opt3"] = "val6"
+
+	assert.NotEqual(t, msg, cloned)
+
+	assert.Equal(t, "val1", msg.Options["opt1"])
+	assert.Equal(t, "val2", msg.Options["opt2"])
+
+	assert.Equal(t, "val5", cloned.Options["opt1"])
+	assert.Equal(t, "val2", cloned.Options["opt2"])
+	assert.Equal(t, "val6", cloned.Options["opt3"])
+}
+
 func TestStartupCodec_Encode(t *testing.T) {
 	codec := &startupCodec{}
 	for _, version := range primitive.AllProtocolVersions() {

--- a/message/supported.go
+++ b/message/supported.go
@@ -35,6 +35,10 @@ func (m *Supported) GetOpCode() primitive.OpCode {
 	return primitive.OpCodeSupported
 }
 
+func (m *Supported) Clone() Message {
+	return &Supported{Options: primitive.CloneSupportedOptions(m.Options)}
+}
+
 func (m *Supported) String() string {
 	return fmt.Sprintf("SUPPORTED %v", m.Options)
 }

--- a/message/supported_test.go
+++ b/message/supported_test.go
@@ -22,6 +22,30 @@ import (
 	"testing"
 )
 
+func TestSupported_Clone(t *testing.T) {
+	msg := &Supported{
+		Options: map[string][]string{
+			"opt1": {"val1"},
+			"opt2": {"val2"},
+		},
+	}
+
+	cloned := msg.Clone().(*Supported)
+	assert.Equal(t, msg, cloned)
+
+	cloned.Options["opt1"] = []string{"val5"}
+	cloned.Options["opt3"] = []string{"val6"}
+
+	assert.NotEqual(t, msg, cloned)
+
+	assert.Equal(t, "val1", msg.Options["opt1"][0])
+	assert.Equal(t, "val2", msg.Options["opt2"][0])
+
+	assert.Equal(t, "val5", cloned.Options["opt1"][0])
+	assert.Equal(t, "val2", cloned.Options["opt2"][0])
+	assert.Equal(t, "val6", cloned.Options["opt3"][0])
+}
+
 func TestSupportedCodec_Encode(test *testing.T) {
 	codec := &supportedCodec{}
 	for _, version := range primitive.AllProtocolVersions() {

--- a/primitive/nillables.go
+++ b/primitive/nillables.go
@@ -25,3 +25,27 @@ type NillableInt64 struct {
 type NillableConsistencyLevel struct {
 	Value ConsistencyLevel
 }
+
+func CloneNillableInt32(n *NillableInt32) *NillableInt32 {
+	if n == nil {
+		return nil
+	}
+
+	return &NillableInt32{Value: n.Value}
+}
+
+func CloneNillableInt64(n *NillableInt64) *NillableInt64 {
+	if n == nil {
+		return nil
+	}
+
+	return &NillableInt64{Value: n.Value}
+}
+
+func CloneNillableConsistencyLevel(n *NillableConsistencyLevel) *NillableConsistencyLevel {
+	if n == nil {
+		return nil
+	}
+
+	return &NillableConsistencyLevel{Value: n.Value}
+}

--- a/primitive/utils.go
+++ b/primitive/utils.go
@@ -1,0 +1,69 @@
+package primitive
+
+import "net"
+
+func CloneByteSlice(o []byte) []byte {
+	if o == nil {
+		return nil
+	}
+
+	newSlice := make([]byte, len(o))
+	copy(newSlice, o)
+	return newSlice
+}
+
+func CloneStringSlice(o []string) []string {
+	if o == nil {
+		return nil
+	}
+
+	newSlice := make([]string, len(o))
+	copy(newSlice, o)
+	return newSlice
+}
+
+func CloneInet(o *Inet) *Inet {
+	var newAddress *Inet
+	if o != nil {
+		var newAddr net.IP
+		if o.Addr != nil {
+			newAddr = make(net.IP, len(o.Addr))
+			copy(newAddr, o.Addr)
+		} else {
+			newAddr = nil
+		}
+		newAddress = &Inet{
+			Addr: newAddr,
+			Port: o.Port,
+		}
+	} else {
+		newAddress = nil
+	}
+	return newAddress
+}
+
+func CloneOptions(o map[string]string) map[string]string {
+	var newMap map[string]string
+	if o != nil {
+		newMap = make(map[string]string)
+		for k, v := range o {
+			newMap[k] = v
+		}
+	} else {
+		newMap = nil
+	}
+	return newMap
+}
+
+func CloneSupportedOptions(o map[string][]string) map[string][]string {
+	var newMap map[string][]string
+	if o != nil {
+		newMap = make(map[string][]string)
+		for k, v := range o {
+			newMap[k] = CloneStringSlice(v)
+		}
+	} else {
+		newMap = nil
+	}
+	return newMap
+}

--- a/primitive/uuid.go
+++ b/primitive/uuid.go
@@ -27,6 +27,11 @@ const LengthOfUuid = 16
 
 type UUID [16]byte
 
+func (u UUID) Clone() UUID {
+	newUuid := u
+	return newUuid
+}
+
 func (u UUID) String() string {
 	return hex.EncodeToString(u[:])
 }

--- a/primitive/values.go
+++ b/primitive/values.go
@@ -50,6 +50,20 @@ func NewUnsetValue() *Value {
 	return &Value{Type: ValueTypeUnset}
 }
 
+func (v *Value) Clone() *Value {
+	var newContents []byte
+	if v.Contents != nil {
+		newContents = make([]byte, len(v.Contents))
+		copy(newContents, v.Contents)
+	} else {
+		newContents = nil
+	}
+	return &Value{
+		Type:     v.Type,
+		Contents: newContents,
+	}
+}
+
 // [value]
 
 func ReadValue(source io.Reader, version ProtocolVersion) (*Value, error) {


### PR DESCRIPTION
Fix #16 

Clone functions are useful for scenarios where the application wants to create a new frame based on an existing one but without modifying the original frame.