### PR TITLE
Fix empty value decoding in primitive readers

### DIFF
--- a/primitive/bytes.go
+++ b/primitive/bytes.go
@@ -27,6 +27,8 @@ func ReadBytes(source io.Reader) ([]byte, error) {
 		return nil, fmt.Errorf("cannot read [bytes] length: %w", err)
 	} else if length < 0 {
 		return nil, nil
+	} else if length == 0 {
+		return []byte{}, nil
 	} else {
 		decoded := make([]byte, length)
 		if read, err := source.Read(decoded); err != nil {

--- a/primitive/bytes_map_test.go
+++ b/primitive/bytes_map_test.go
@@ -102,11 +102,18 @@ func TestReadBytesMap(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			buf := bytes.NewBuffer(tt.source)
+			buf := bytes.NewReader(tt.source)
 			actual, err := ReadBytesMap(buf)
 			assert.Equal(t, tt.expected, actual)
-			assert.Equal(t, tt.remaining, buf.Bytes())
 			assert.Equal(t, tt.err, err)
+			remaining := make([]byte, buf.Len())
+			_, err = buf.Read(remaining)
+			if len(tt.remaining) == 0 {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, tt.remaining, remaining)
+			}
 		})
 	}
 }

--- a/primitive/bytes_map_test.go
+++ b/primitive/bytes_map_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/stretchr/testify/assert"
+	"io/ioutil"
 	"testing"
 )
 
@@ -106,14 +107,8 @@ func TestReadBytesMap(t *testing.T) {
 			actual, err := ReadBytesMap(buf)
 			assert.Equal(t, tt.expected, actual)
 			assert.Equal(t, tt.err, err)
-			remaining := make([]byte, buf.Len())
-			_, err = buf.Read(remaining)
-			if len(tt.remaining) == 0 {
-				assert.NotNil(t, err)
-			} else {
-				assert.Nil(t, err)
-				assert.Equal(t, tt.remaining, remaining)
-			}
+			remaining, _ := ioutil.ReadAll(buf)
+			assert.Equal(t, tt.remaining, remaining)
 		})
 	}
 }

--- a/primitive/bytes_test.go
+++ b/primitive/bytes_test.go
@@ -51,11 +51,19 @@ func TestReadBytes(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			buf := bytes.NewBuffer(tt.source)
+			buf := bytes.NewReader(tt.source)
 			actual, err := ReadBytes(buf)
-			assert.Equal(t, tt.expected, actual)
-			assert.Equal(t, tt.remaining, buf.Bytes())
 			assert.Equal(t, tt.err, err)
+			assert.Equal(t, tt.expected, actual)
+
+			remaining := make([]byte, buf.Len())
+			_, err = buf.Read(remaining)
+			if len(tt.remaining) == 0 {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, tt.remaining, remaining)
+			}
 		})
 	}
 }

--- a/primitive/bytes_test.go
+++ b/primitive/bytes_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/stretchr/testify/assert"
+	"io/ioutil"
 	"testing"
 )
 
@@ -56,14 +57,8 @@ func TestReadBytes(t *testing.T) {
 			assert.Equal(t, tt.err, err)
 			assert.Equal(t, tt.expected, actual)
 
-			remaining := make([]byte, buf.Len())
-			_, err = buf.Read(remaining)
-			if len(tt.remaining) == 0 {
-				assert.NotNil(t, err)
-			} else {
-				assert.Nil(t, err)
-				assert.Equal(t, tt.remaining, remaining)
-			}
+			remaining, _ := ioutil.ReadAll(buf)
+			assert.Equal(t, tt.remaining, remaining)
 		})
 	}
 }

--- a/primitive/long_string.go
+++ b/primitive/long_string.go
@@ -25,6 +25,8 @@ import (
 func ReadLongString(source io.Reader) (string, error) {
 	if length, err := ReadInt(source); err != nil {
 		return "", fmt.Errorf("cannot read [long string] length: %w", err)
+	} else if length <= 0 {
+		return "", nil
 	} else {
 		decoded := make([]byte, length)
 		if read, err := source.Read(decoded); err != nil {

--- a/primitive/long_string_test.go
+++ b/primitive/long_string_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/stretchr/testify/assert"
+	"io/ioutil"
 	"testing"
 )
 
@@ -60,14 +61,8 @@ func TestReadLongString(t *testing.T) {
 			actual, err := ReadLongString(buf)
 			assert.Equal(t, tt.expected, actual)
 			assert.Equal(t, tt.err, err)
-			remaining := make([]byte, buf.Len())
-			_, err = buf.Read(remaining)
-			if len(tt.remaining) == 0 {
-				assert.NotNil(t, err)
-			} else {
-				assert.Nil(t, err)
-				assert.Equal(t, tt.remaining, remaining)
-			}
+			remaining, _ := ioutil.ReadAll(buf)
+			assert.Equal(t, tt.remaining, remaining)
 		})
 	}
 }

--- a/primitive/long_string_test.go
+++ b/primitive/long_string_test.go
@@ -56,11 +56,18 @@ func TestReadLongString(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			buf := bytes.NewBuffer(tt.source)
+			buf := bytes.NewReader(tt.source)
 			actual, err := ReadLongString(buf)
 			assert.Equal(t, tt.expected, actual)
-			assert.Equal(t, tt.remaining, buf.Bytes())
 			assert.Equal(t, tt.err, err)
+			remaining := make([]byte, buf.Len())
+			_, err = buf.Read(remaining)
+			if len(tt.remaining) == 0 {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, tt.remaining, remaining)
+			}
 		})
 	}
 }

--- a/primitive/short_bytes.go
+++ b/primitive/short_bytes.go
@@ -25,6 +25,10 @@ import (
 func ReadShortBytes(source io.Reader) ([]byte, error) {
 	if length, err := ReadShort(source); err != nil {
 		return nil, fmt.Errorf("cannot read [short bytes] length: %w", err)
+	} else if length < 0 {
+		return nil, nil
+	} else if length == 0 {
+		return []byte{}, nil
 	} else {
 		decoded := make([]byte, length)
 		if read, err := source.Read(decoded); err != nil {

--- a/primitive/short_bytes_test.go
+++ b/primitive/short_bytes_test.go
@@ -50,11 +50,18 @@ func TestReadShortBytes(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			buf := bytes.NewBuffer(tt.source)
+			buf := bytes.NewReader(tt.source)
 			actual, err := ReadShortBytes(buf)
 			assert.Equal(t, tt.expected, actual)
-			assert.Equal(t, tt.remaining, buf.Bytes())
 			assert.Equal(t, tt.err, err)
+			remaining := make([]byte, buf.Len())
+			_, err = buf.Read(remaining)
+			if len(tt.remaining) == 0 {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, tt.remaining, remaining)
+			}
 		})
 	}
 }

--- a/primitive/short_bytes_test.go
+++ b/primitive/short_bytes_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/stretchr/testify/assert"
+	"io/ioutil"
 	"testing"
 )
 
@@ -54,14 +55,8 @@ func TestReadShortBytes(t *testing.T) {
 			actual, err := ReadShortBytes(buf)
 			assert.Equal(t, tt.expected, actual)
 			assert.Equal(t, tt.err, err)
-			remaining := make([]byte, buf.Len())
-			_, err = buf.Read(remaining)
-			if len(tt.remaining) == 0 {
-				assert.NotNil(t, err)
-			} else {
-				assert.Nil(t, err)
-				assert.Equal(t, tt.remaining, remaining)
-			}
+			remaining, _ := ioutil.ReadAll(buf)
+			assert.Equal(t, tt.remaining, remaining)
 		})
 	}
 }

--- a/primitive/streamid_test.go
+++ b/primitive/streamid_test.go
@@ -52,7 +52,7 @@ func TestReadStreamId(t *testing.T) {
 			}
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
-					buf := bytes.NewBuffer(tt.source)
+					buf := bytes.NewReader(tt.source)
 					actual, err := ReadStreamId(buf, version)
 					assert.Equal(t, tt.expected, actual)
 					assert.Equal(t, tt.err, err)
@@ -89,7 +89,7 @@ func TestReadStreamId(t *testing.T) {
 			}
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
-					buf := bytes.NewBuffer(tt.source)
+					buf := bytes.NewReader(tt.source)
 					actual, err := ReadStreamId(buf, version)
 					assert.Equal(t, tt.expected, actual)
 					assert.Equal(t, tt.err, err)

--- a/primitive/string.go
+++ b/primitive/string.go
@@ -25,6 +25,8 @@ import (
 func ReadString(source io.Reader) (string, error) {
 	if length, err := ReadShort(source); err != nil {
 		return "", fmt.Errorf("cannot read [string] length: %w", err)
+	} else if length <= 0 {
+		return "", nil
 	} else {
 		decoded := make([]byte, length)
 		if read, err := source.Read(decoded); err != nil {

--- a/primitive/string_list.go
+++ b/primitive/string_list.go
@@ -27,6 +27,13 @@ func ReadStringList(source io.Reader) (decoded []string, err error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot read [string list] length: %w", err)
 	}
+
+	if length < 0 {
+		return nil, nil
+	} else if length == 0 {
+		return []string{}, nil
+	}
+
 	decoded = make([]string, length)
 	for i := uint16(0); i < length; i++ {
 		var str string

--- a/primitive/string_list_test.go
+++ b/primitive/string_list_test.go
@@ -62,11 +62,18 @@ func TestReadStringList(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			buf := bytes.NewBuffer(tt.source)
+			buf := bytes.NewReader(tt.source)
 			actual, err := ReadStringList(buf)
 			assert.Equal(t, tt.expected, actual)
-			assert.Equal(t, tt.remaining, buf.Bytes())
 			assert.Equal(t, tt.err, err)
+			remaining := make([]byte, buf.Len())
+			_, err = buf.Read(remaining)
+			if len(tt.remaining) == 0 {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, tt.remaining, remaining)
+			}
 		})
 	}
 }

--- a/primitive/string_list_test.go
+++ b/primitive/string_list_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/stretchr/testify/assert"
+	"io/ioutil"
 	"testing"
 )
 
@@ -66,14 +67,8 @@ func TestReadStringList(t *testing.T) {
 			actual, err := ReadStringList(buf)
 			assert.Equal(t, tt.expected, actual)
 			assert.Equal(t, tt.err, err)
-			remaining := make([]byte, buf.Len())
-			_, err = buf.Read(remaining)
-			if len(tt.remaining) == 0 {
-				assert.NotNil(t, err)
-			} else {
-				assert.Nil(t, err)
-				assert.Equal(t, tt.remaining, remaining)
-			}
+			remaining, _ := ioutil.ReadAll(buf)
+			assert.Equal(t, tt.remaining, remaining)
 		})
 	}
 }

--- a/primitive/string_map_test.go
+++ b/primitive/string_map_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/stretchr/testify/assert"
+	"io/ioutil"
 	"testing"
 )
 
@@ -100,14 +101,8 @@ func TestReadStringMap(t *testing.T) {
 			actual, err := ReadStringMap(buf)
 			assert.Equal(t, tt.expected, actual)
 			assert.Equal(t, tt.err, err)
-			remaining := make([]byte, buf.Len())
-			_, err = buf.Read(remaining)
-			if len(tt.remaining) == 0 {
-				assert.NotNil(t, err)
-			} else {
-				assert.Nil(t, err)
-				assert.Equal(t, tt.remaining, remaining)
-			}
+			remaining, _ := ioutil.ReadAll(buf)
+			assert.Equal(t, tt.remaining, remaining)
 		})
 	}
 }

--- a/primitive/string_map_test.go
+++ b/primitive/string_map_test.go
@@ -96,11 +96,18 @@ func TestReadStringMap(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			buf := bytes.NewBuffer(tt.source)
+			buf := bytes.NewReader(tt.source)
 			actual, err := ReadStringMap(buf)
 			assert.Equal(t, tt.expected, actual)
-			assert.Equal(t, tt.remaining, buf.Bytes())
 			assert.Equal(t, tt.err, err)
+			remaining := make([]byte, buf.Len())
+			_, err = buf.Read(remaining)
+			if len(tt.remaining) == 0 {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, tt.remaining, remaining)
+			}
 		})
 	}
 }

--- a/primitive/string_multimap_test.go
+++ b/primitive/string_multimap_test.go
@@ -115,11 +115,18 @@ func TestReadStringMultiMap(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			buf := bytes.NewBuffer(tt.source)
+			buf := bytes.NewReader(tt.source)
 			actual, err := ReadStringMultiMap(buf)
 			assert.Equal(t, tt.expected, actual)
-			assert.Equal(t, tt.remaining, buf.Bytes())
 			assert.Equal(t, tt.err, err)
+			remaining := make([]byte, buf.Len())
+			_, err = buf.Read(remaining)
+			if len(tt.remaining) == 0 {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, tt.remaining, remaining)
+			}
 		})
 	}
 }

--- a/primitive/string_multimap_test.go
+++ b/primitive/string_multimap_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/stretchr/testify/assert"
+	"io/ioutil"
 	"testing"
 )
 
@@ -119,14 +120,8 @@ func TestReadStringMultiMap(t *testing.T) {
 			actual, err := ReadStringMultiMap(buf)
 			assert.Equal(t, tt.expected, actual)
 			assert.Equal(t, tt.err, err)
-			remaining := make([]byte, buf.Len())
-			_, err = buf.Read(remaining)
-			if len(tt.remaining) == 0 {
-				assert.NotNil(t, err)
-			} else {
-				assert.Nil(t, err)
-				assert.Equal(t, tt.remaining, remaining)
-			}
+			remaining, _ := ioutil.ReadAll(buf)
+			assert.Equal(t, tt.remaining, remaining)
 		})
 	}
 }

--- a/primitive/string_test.go
+++ b/primitive/string_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/stretchr/testify/assert"
+	"io/ioutil"
 	"testing"
 )
 
@@ -74,14 +75,8 @@ func TestReadString(t *testing.T) {
 			actual, err := ReadString(buf)
 			assert.Equal(t, tt.expected, actual)
 			assert.Equal(t, tt.err, err)
-			remaining := make([]byte, buf.Len())
-			_, err = buf.Read(remaining)
-			if len(tt.remaining) == 0 {
-				assert.NotNil(t, err)
-			} else {
-				assert.Nil(t, err)
-				assert.Equal(t, tt.remaining, remaining)
-			}
+			remaining, _ := ioutil.ReadAll(buf)
+			assert.Equal(t, tt.remaining, remaining)
 		})
 	}
 }

--- a/primitive/string_test.go
+++ b/primitive/string_test.go
@@ -70,11 +70,18 @@ func TestReadString(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			buf := bytes.NewBuffer(tt.source)
+			buf := bytes.NewReader(tt.source)
 			actual, err := ReadString(buf)
 			assert.Equal(t, tt.expected, actual)
-			assert.Equal(t, tt.remaining, buf.Bytes())
 			assert.Equal(t, tt.err, err)
+			remaining := make([]byte, buf.Len())
+			_, err = buf.Read(remaining)
+			if len(tt.remaining) == 0 {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, tt.remaining, remaining)
+			}
 		})
 	}
 }

--- a/primitive/values.go
+++ b/primitive/values.go
@@ -78,6 +78,8 @@ func ReadValue(source io.Reader, version ProtocolVersion) (*Value, error) {
 		return NewUnsetValue(), nil
 	} else if length < 0 {
 		return nil, fmt.Errorf("invalid [value] length: %v", length)
+	} else if length == 0 {
+		return NewValue([]byte{}), nil
 	} else {
 		decoded := make([]byte, length)
 		if read, err := source.Read(decoded); err != nil {

--- a/primitive/values_test.go
+++ b/primitive/values_test.go
@@ -96,7 +96,7 @@ func TestReadValue(t *testing.T) {
 			}
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
-					buf := bytes.NewBuffer(tt.source)
+					buf := bytes.NewReader(tt.source)
 					actual, err := ReadValue(buf, version)
 					assert.Equal(t, tt.expected, actual)
 					assert.Equal(t, tt.err, err)
@@ -177,7 +177,7 @@ func TestReadValue(t *testing.T) {
 			}
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
-					buf := bytes.NewBuffer(tt.source)
+					buf := bytes.NewReader(tt.source)
 					actual, err := ReadValue(buf, version)
 					assert.Equal(t, tt.expected, actual)
 					assert.Equal(t, tt.err, err)


### PR DESCRIPTION
Fix #19 