### PR TITLE
Add a typed protocol error to the decode header function

### DIFF
--- a/frame/codec.go
+++ b/frame/codec.go
@@ -148,3 +148,21 @@ func (c *codec) findMessageCodec(opCode primitive.OpCode) (message.Codec, error)
 		return encoder, nil
 	}
 }
+
+type ProtocolVersionErr struct {
+	Err     string
+	Version primitive.ProtocolVersion
+	UseBeta bool
+}
+
+func NewProtocolVersionErr(err string, version primitive.ProtocolVersion, useBeta bool) *ProtocolVersionErr {
+	return &ProtocolVersionErr{
+		Err:     err,
+		Version: version,
+		UseBeta: useBeta,
+	}
+}
+
+func (e *ProtocolVersionErr) Error() string {
+	return fmt.Sprintf("unsupported protocol version (version=%s, useBeta=%v): %s", e.Version, e.UseBeta, e.Err)
+}

--- a/frame/decode.go
+++ b/frame/decode.go
@@ -145,19 +145,19 @@ func (c *codec) DiscardBody(header *Header, source io.Reader) (err error) {
 }
 
 type ProtocolVersionErr struct {
-	err     string
-	version primitive.ProtocolVersion
-	useBeta bool
+	Err     string
+	Version primitive.ProtocolVersion
+	UseBeta bool
 }
 
 func NewProtocolVersionErr(err string, version primitive.ProtocolVersion, useBeta bool) *ProtocolVersionErr {
 	return &ProtocolVersionErr{
-		err:     err,
-		version: version,
-		useBeta: useBeta,
+		Err:     err,
+		Version: version,
+		UseBeta: useBeta,
 	}
 }
 
 func (e *ProtocolVersionErr) Error() string {
-	return fmt.Sprintf("%s (version=%s, useBeta=%v)", e.err, e.version, e.useBeta)
+	return fmt.Sprintf("%s (version=%s, useBeta=%v)", e.Err, e.Version, e.UseBeta)
 }

--- a/frame/decode.go
+++ b/frame/decode.go
@@ -64,8 +64,6 @@ func (c *codec) DecodeHeader(source io.Reader) (*Header, error) {
 		var opCode uint8
 		if err = primitive.CheckValidProtocolVersion(version); err != nil {
 			return nil, NewProtocolVersionErr(err.Error(), version, useBetaFlag)
-		} else if flags, err = primitive.ReadByte(source); err != nil {
-			return nil, fmt.Errorf("cannot decode header flags: %w", err)
 		} else if version.IsBeta() && !useBetaFlag {
 			return nil, NewProtocolVersionErr("expected USE_BETA flag to be set", version, useBetaFlag)
 		} else if header.StreamId, err = primitive.ReadStreamId(source, version); err != nil {

--- a/frame/decode.go
+++ b/frame/decode.go
@@ -53,14 +53,21 @@ func (c *codec) DecodeHeader(source io.Reader) (*Header, error) {
 			IsResponse: isResponse,
 			Version:    version,
 		}
+
 		var flags uint8
+		var err error
+		if flags, err = primitive.ReadByte(source); err != nil {
+			return nil, fmt.Errorf("cannot decode header flags: %w", err)
+		}
+		useBetaFlag := primitive.HeaderFlag(flags).Contains(primitive.HeaderFlagUseBeta)
+
 		var opCode uint8
-		if err := primitive.CheckValidProtocolVersion(version); err != nil {
-			return nil, err
+		if err = primitive.CheckValidProtocolVersion(version); err != nil {
+			return nil, NewProtocolVersionErr(err.Error(), version, useBetaFlag)
 		} else if flags, err = primitive.ReadByte(source); err != nil {
 			return nil, fmt.Errorf("cannot decode header flags: %w", err)
-		} else if version.IsBeta() && !primitive.HeaderFlag(flags).Contains(primitive.HeaderFlagUseBeta) {
-			return nil, NewProtocolVersionErr("expected USE_BETA flag to be set", version, false)
+		} else if version.IsBeta() && !useBetaFlag {
+			return nil, NewProtocolVersionErr("expected USE_BETA flag to be set", version, useBetaFlag)
 		} else if header.StreamId, err = primitive.ReadStreamId(source, version); err != nil {
 			return nil, fmt.Errorf("cannot decode header stream id: %w", err)
 		} else if opCode, err = primitive.ReadByte(source); err != nil {
@@ -142,22 +149,4 @@ func (c *codec) DiscardBody(header *Header, source io.Reader) (err error) {
 		err = fmt.Errorf("cannot discard body; %w", err)
 	}
 	return err
-}
-
-type ProtocolVersionErr struct {
-	Err     string
-	Version primitive.ProtocolVersion
-	UseBeta bool
-}
-
-func NewProtocolVersionErr(err string, version primitive.ProtocolVersion, useBeta bool) *ProtocolVersionErr {
-	return &ProtocolVersionErr{
-		Err:     err,
-		Version: version,
-		UseBeta: useBeta,
-	}
-}
-
-func (e *ProtocolVersionErr) Error() string {
-	return fmt.Sprintf("%s (version=%s, useBeta=%v)", e.Err, e.Version, e.UseBeta)
 }

--- a/frame/encode.go
+++ b/frame/encode.go
@@ -74,9 +74,13 @@ func (c *codec) EncodeRawFrame(frame *RawFrame, dest io.Writer) error {
 }
 
 func (c *codec) EncodeHeader(header *Header, dest io.Writer) error {
+	useBetaFlag := header.Flags.Contains(primitive.HeaderFlagUseBeta)
 	if err := primitive.CheckValidProtocolVersion(header.Version); err != nil {
-		return err
+		return NewProtocolVersionErr(err.Error(), header.Version, useBetaFlag)
+	} else if header.Version.IsBeta() && !useBetaFlag {
+		return NewProtocolVersionErr("expected USE_BETA flag to be set", header.Version, useBetaFlag)
 	}
+
 	versionAndDirection := uint8(header.Version)
 	if header.IsResponse {
 		versionAndDirection |= 0b1000_0000


### PR DESCRIPTION
Currently, if a request comes with the v5 version but without the beta flag, the `DecodeHeader` function will return an error. 

The caller can mitigate this if it is aware of this error, so this PR introduces a new error type for these protocol errors.