### PR TITLE
Allow empty batches

### DIFF
--- a/message/batch.go
+++ b/message/batch.go
@@ -139,9 +139,7 @@ func (c *batchCodec) Encode(msg Message, dest io.Writer, version primitive.Proto
 		return fmt.Errorf("cannot write BATCH type: %w", err)
 	}
 	childrenCount := len(batch.Children)
-	if childrenCount == 0 {
-		return errors.New("BATCH messages must contain at least one child query")
-	} else if childrenCount > 0xFFFF {
+	if childrenCount > 0xFFFF {
 		return errors.New(fmt.Sprintf("BATCH messages can contain at most %d child queries", 0xFFFF))
 	} else if err = primitive.WriteShort(uint16(childrenCount), dest); err != nil {
 		return fmt.Errorf("cannot write BATCH query count: %w", err)

--- a/message/batch_test.go
+++ b/message/batch_test.go
@@ -96,8 +96,12 @@ func TestBatchCodec_Encode(t *testing.T) {
 			{
 				"empty batch",
 				&Batch{},
-				[]byte{byte(primitive.BatchTypeLogged)},
-				errors.New("BATCH messages must contain at least one child query"),
+				[]byte{
+					byte(primitive.BatchTypeLogged),
+					0, 0, // children count
+					0, 0, // consistency level
+				},
+				nil,
 			},
 			{
 				"batch with 2 children",
@@ -157,8 +161,13 @@ func TestBatchCodec_Encode(t *testing.T) {
 				{
 					"empty batch",
 					&Batch{},
-					[]byte{byte(primitive.BatchTypeLogged)},
-					errors.New("BATCH messages must contain at least one child query"),
+					[]byte{
+						byte(primitive.BatchTypeLogged),
+						0, 0, // children count
+						0, 0, // consistency level
+						0, // flags
+					},
+					nil,
 				},
 				{
 					"batch with 2 children",
@@ -247,8 +256,13 @@ func TestBatchCodec_Encode(t *testing.T) {
 			{
 				"empty batch",
 				&Batch{},
-				[]byte{byte(primitive.BatchTypeLogged)},
-				errors.New("BATCH messages must contain at least one child query"),
+				[]byte{
+					byte(primitive.BatchTypeLogged),
+					0, 0, // children count
+					0, 0, // consistency level
+					0, 0, 0, 0, // flags
+				},
+				nil,
 			},
 			{
 				"batch with 2 children",
@@ -343,8 +357,13 @@ func TestBatchCodec_Encode(t *testing.T) {
 			{
 				"empty batch",
 				&Batch{},
-				[]byte{byte(primitive.BatchTypeLogged)},
-				errors.New("BATCH messages must contain at least one child query"),
+				[]byte{
+					byte(primitive.BatchTypeLogged),
+					0, 0, // children count
+					0, 0, // consistency level
+					0, 0, 0, 0, // flags
+				},
+				nil,
 			},
 			{
 				"batch with 2 children",
@@ -432,8 +451,13 @@ func TestBatchCodec_Encode(t *testing.T) {
 			{
 				"empty batch",
 				&Batch{},
-				[]byte{byte(primitive.BatchTypeLogged)},
-				errors.New("BATCH messages must contain at least one child query"),
+				[]byte{
+					byte(primitive.BatchTypeLogged),
+					0, 0, // children count
+					0, 0, // consistency level
+					0, 0, 0, 0, // flags
+				},
+				nil,
 			},
 			{
 				"batch with 2 children",


### PR DESCRIPTION
We just ran into an issue where a client is sending empty batches and they are usually supported by drivers and C* (even though they probably shouldn't be) so I'm proposing the removal of this restriction on this library.