### PR TITLE
Remove check that prevents requests with an empty query string to be decoded

### DIFF
--- a/message/query.go
+++ b/message/query.go
@@ -86,9 +86,6 @@ func (c *queryCodec) EncodedLength(msg Message, version primitive.ProtocolVersio
 func (c *queryCodec) Decode(source io.Reader, version primitive.ProtocolVersion) (Message, error) {
 	if query, err := primitive.ReadLongString(source); err != nil {
 		return nil, err
-	// TODO commenting out to test fix - to be removed
-	//} else if query == "" {
-	//	return nil, fmt.Errorf("cannot read QUERY empty query string")
 	} else if options, err := DecodeQueryOptions(source, version); err != nil {
 		return nil, err
 	} else {

--- a/message/query.go
+++ b/message/query.go
@@ -59,9 +59,7 @@ func (c *queryCodec) Encode(msg Message, dest io.Writer, version primitive.Proto
 	if !ok {
 		return errors.New(fmt.Sprintf("expected *message.Query, got %T", msg))
 	}
-	if query.Query == "" {
-		return errors.New("cannot write QUERY empty query string")
-	} else if err := primitive.WriteLongString(query.Query, dest); err != nil {
+	if err := primitive.WriteLongString(query.Query, dest); err != nil {
 		return fmt.Errorf("cannot write QUERY query string: %w", err)
 	}
 	if err := EncodeQueryOptions(query.Options, dest, version); err != nil {

--- a/message/query.go
+++ b/message/query.go
@@ -86,8 +86,9 @@ func (c *queryCodec) EncodedLength(msg Message, version primitive.ProtocolVersio
 func (c *queryCodec) Decode(source io.Reader, version primitive.ProtocolVersion) (Message, error) {
 	if query, err := primitive.ReadLongString(source); err != nil {
 		return nil, err
-	} else if query == "" {
-		return nil, fmt.Errorf("cannot read QUERY empty query string")
+	// TODO commenting out to test fix - to be removed
+	//} else if query == "" {
+	//	return nil, fmt.Errorf("cannot read QUERY empty query string")
 	} else if options, err := DecodeQueryOptions(source, version); err != nil {
 		return nil, err
 	} else {

--- a/message/query_test.go
+++ b/message/query_test.go
@@ -226,7 +226,7 @@ func TestQueryCodec_Encode(t *testing.T) {
 				nil,
 			},
 			{
-				"missing query",
+				"query with empty query string",
 				&Query{},
 				nil,
 				errors.New("cannot write QUERY empty query string"),
@@ -337,7 +337,7 @@ func TestQueryCodec_Encode(t *testing.T) {
 				nil,
 			},
 			{
-				"missing query",
+				"query with empty query string",
 				&Query{},
 				nil,
 				errors.New("cannot write QUERY empty query string"),
@@ -457,7 +457,7 @@ func TestQueryCodec_Encode(t *testing.T) {
 				nil,
 			},
 			{
-				"missing query",
+				"query with empty query string",
 				&Query{},
 				nil,
 				errors.New("cannot write QUERY empty query string"),
@@ -652,7 +652,7 @@ func TestQueryCodec_Encode(t *testing.T) {
 				nil,
 			},
 			{
-				"missing query",
+				"query with empty query string",
 				&Query{},
 				nil,
 				errors.New("cannot write QUERY empty query string"),
@@ -1393,14 +1393,17 @@ func TestQueryCodec_Decode(t *testing.T) {
 				nil,
 			},
 			{
-				"missing query",
+				"query with empty query string",
 				[]byte{
 					0, 0, 0, 0, // empty query
 					0, 0, // consistency level
 					0, // flags
 				},
+				&Query{
+					Query: "",
+					Options: &QueryOptions{},
+				},
 				nil,
-				errors.New("cannot read QUERY empty query string"),
 			},
 		}
 		for _, tt := range tests {
@@ -1502,14 +1505,17 @@ func TestQueryCodec_Decode(t *testing.T) {
 				nil,
 			},
 			{
-				"missing query",
+				"query with empty query string",
 				[]byte{
 					0, 0, 0, 0, // empty query
 					0, 0, // consistency level
 					0, // flags
 				},
+				&Query{
+					Query: "",
+					Options: &QueryOptions{},
+				},
 				nil,
-				errors.New("cannot read QUERY empty query string"),
 			},
 		}
 		for _, tt := range tests {
@@ -1620,14 +1626,17 @@ func TestQueryCodec_Decode(t *testing.T) {
 				nil,
 			},
 			{
-				"missing query",
+				"query with empty query string",
 				[]byte{
 					0, 0, 0, 0, // empty query
 					0, 0, // consistency level
 					0, // flags
 				},
+				&Query{
+					Query: "",
+					Options: &QueryOptions{},
+				},
 				nil,
-				errors.New("cannot read QUERY empty query string"),
 			},
 		}
 		for _, tt := range tests {
@@ -1813,14 +1822,17 @@ func TestQueryCodec_Decode(t *testing.T) {
 				nil,
 			},
 			{
-				"missing query",
+				"query with empty query string",
 				[]byte{
 					0, 0, 0, 0, // empty query
 					0, 0, // consistency level
 					0, 0, 0, 0, // flags
 				},
+				&Query{
+					Query: "",
+					Options: &QueryOptions{},
+				},
 				nil,
-				errors.New("cannot read QUERY empty query string"),
 			},
 		}
 		for _, tt := range tests {

--- a/message/query_test.go
+++ b/message/query_test.go
@@ -228,8 +228,12 @@ func TestQueryCodec_Encode(t *testing.T) {
 			{
 				"query with empty query string",
 				&Query{},
+				[]byte{
+					0, 0, 0, 0, // empty query
+					0, 0, // consistency level
+					0, // flags
+				},
 				nil,
-				errors.New("cannot write QUERY empty query string"),
 			},
 			{
 				"not a query",
@@ -339,8 +343,12 @@ func TestQueryCodec_Encode(t *testing.T) {
 			{
 				"query with empty query string",
 				&Query{},
+				[]byte{
+					0, 0, 0, 0, // empty query
+					0, 0, // consistency level
+					0, // flags
+				},
 				nil,
-				errors.New("cannot write QUERY empty query string"),
 			},
 			{
 				"not a query",
@@ -459,8 +467,12 @@ func TestQueryCodec_Encode(t *testing.T) {
 			{
 				"query with empty query string",
 				&Query{},
+				[]byte{
+					0, 0, 0, 0, // empty query
+					0, 0, // consistency level
+					0, // flags
+				},
 				nil,
-				errors.New("cannot write QUERY empty query string"),
 			},
 			{
 				"not a query",
@@ -654,8 +666,12 @@ func TestQueryCodec_Encode(t *testing.T) {
 			{
 				"query with empty query string",
 				&Query{},
+				[]byte{
+					0, 0, 0, 0, // empty query
+					0, 0, // consistency level
+					0, 0, 0, 0, // flags
+				},
 				nil,
-				errors.New("cannot write QUERY empty query string"),
 			},
 			{
 				"not a query",


### PR DESCRIPTION
The decoder was throwing an error when the query string was empty. As this is a valid scenario that the driver supports (e.g. when using the GraphBinary subprotocol for Gremlin fluent APIs), I removed this check and ensured that a query with an empty query string is decoded successfully, returning an empty Query struct and query options.

I amended the existing tests to reflect this behaviour.

Fixes issue #44.