### PR TITLE
fix check license action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Check license
       run: |
-        go get -u github.com/google/addlicense
+        go install github.com/google/addlicense@latest
         addlicense -check **/*.go
 
     - name: Build


### PR DESCRIPTION
The check license action is failing the builds atm.

```
Run go get -u github.com/google/addlicense
go: downloading github.com/google/addlicense v1.0.0
go: downloading github.com/bmatcuk/doublestar/v4 v4.0.2
go: downloading golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
go: downloading github.com/bmatcuk/doublestar v1.3.4
go: downloading golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
go: added github.com/google/addlicense v1.0.0
go: upgraded golang.org/x/sync v0.0.0-20190423024810-112230192c58 => v0.0.0-20210220032951-036812b2e83c
/home/runner/work/_temp/392680e6-6dda-4943-a0ea-18e0249e72d9.sh: line 2: addlicense: command not found
Error: Process completed with exit code 127.
```