### PR TITLE
Add raw request handler

### DIFF
--- a/client/handlers_test.go
+++ b/client/handlers_test.go
@@ -15,6 +15,7 @@
 package client_test
 
 import (
+	"bytes"
 	"context"
 	"github.com/datastax/go-cassandra-native-protocol/client"
 	"github.com/datastax/go-cassandra-native-protocol/frame"
@@ -28,7 +29,7 @@ import (
 
 func TestHeartbeatHandler(t *testing.T) {
 
-	server, clientConn, cancelFn := createServerAndClient(t, client.HeartbeatHandler)
+	server, clientConn, cancelFn := createServerAndClient(t, []client.RequestHandler{client.HeartbeatHandler}, nil)
 	defer cancelFn()
 
 	testHeartbeat(t, clientConn)
@@ -45,7 +46,7 @@ func TestSetKeyspaceHandler(t *testing.T) {
 		require.Equal(t, "ks1", keyspace)
 		onKeyspaceSetCalled = true
 	}
-	server, clientConn, cancelFn := createServerAndClient(t, client.NewSetKeyspaceHandler(onKeyspaceSet))
+	server, clientConn, cancelFn := createServerAndClient(t, []client.RequestHandler{client.NewSetKeyspaceHandler(onKeyspaceSet)}, nil)
 	defer cancelFn()
 
 	testUseQuery(t, clientConn)
@@ -58,7 +59,7 @@ func TestSetKeyspaceHandler(t *testing.T) {
 
 func TestRegisterHandler(t *testing.T) {
 
-	server, clientConn, cancelFn := createServerAndClient(t, client.RegisterHandler)
+	server, clientConn, cancelFn := createServerAndClient(t, []client.RequestHandler{client.RegisterHandler}, nil)
 	defer cancelFn()
 
 	testRegister(t, clientConn)
@@ -71,7 +72,7 @@ func TestRegisterHandler(t *testing.T) {
 func TestNewCompositeRequestHandler(t *testing.T) {
 
 	handler := client.NewCompositeRequestHandler(client.HeartbeatHandler, client.RegisterHandler)
-	server, clientConn, cancelFn := createServerAndClient(t, handler)
+	server, clientConn, cancelFn := createServerAndClient(t, []client.RequestHandler{handler}, nil)
 	defer cancelFn()
 
 	testHeartbeat(t, clientConn)
@@ -88,7 +89,7 @@ func TestNewDriverConnectionInitializationHandler(t *testing.T) {
 		require.Equal(t, "ks1", keyspace)
 	}
 	handler := client.NewDriverConnectionInitializationHandler("cluster_test", "datacenter_test", onKeyspaceSet)
-	server, clientConn, cancelFn := createServerAndClient(t, handler)
+	server, clientConn, cancelFn := createServerAndClient(t, []client.RequestHandler{handler}, nil)
 	defer cancelFn()
 
 	err := clientConn.InitiateHandshake(primitive.ProtocolVersion4, client.ManagedStreamId)
@@ -107,9 +108,32 @@ func TestNewDriverConnectionInitializationHandler(t *testing.T) {
 
 }
 
-func createServerAndClient(t *testing.T, handlers ...client.RequestHandler) (*client.CqlServer, *client.CqlClientConnection, context.CancelFunc) {
+func TestRawHandler(t *testing.T) {
+	var rawHandler client.RequestRawHandler
+	rawHandler = func(request *frame.Frame, conn *client.CqlServerConnection, ctx client.RequestHandlerContext) (rawResponse []byte) {
+		bytesBuf := bytes.Buffer{}
+		err := frame.NewCodec().EncodeFrame(frame.NewFrame(primitive.ProtocolVersion4, 1, &message.Ready{}), &bytesBuf)
+		if err == nil {
+			return bytesBuf.Bytes()
+		} else {
+			return nil
+		}
+	}
+	server, clientConn, cancelFn := createServerAndClient(
+		t, []client.RequestHandler{client.HeartbeatHandler}, []client.RequestRawHandler{rawHandler})
+	defer cancelFn()
+
+	testRawRequestHandler(t, clientConn)
+
+	cancelFn()
+	checkClosed(t, clientConn, server)
+
+}
+
+func createServerAndClient(t *testing.T, handlers []client.RequestHandler, rawHandlers []client.RequestRawHandler) (*client.CqlServer, *client.CqlClientConnection, context.CancelFunc) {
 	server := client.NewCqlServer("127.0.0.1:9043", nil)
 	server.RequestHandlers = handlers
+	server.RequestRawHandlers = rawHandlers
 	clt := client.NewCqlClient("127.0.0.1:9043", nil)
 	ctx, cancelFn := context.WithCancel(context.Background())
 	err := server.Start(ctx)
@@ -123,6 +147,21 @@ func createServerAndClient(t *testing.T, handlers ...client.RequestHandler) (*cl
 func checkClosed(t *testing.T, clientConn *client.CqlClientConnection, server *client.CqlServer) {
 	assert.Eventually(t, clientConn.IsClosed, time.Second*10, time.Millisecond*10)
 	assert.Eventually(t, server.IsClosed, time.Second*10, time.Millisecond*10)
+}
+
+func testRawRequestHandler(t *testing.T, clientConn *client.CqlClientConnection) {
+	heartbeat := frame.NewFrame(
+		primitive.ProtocolVersion4,
+		client.ManagedStreamId,
+		&message.Options{},
+	)
+	for i := 0; i < 100; i++ {
+		response, err := clientConn.SendAndReceive(heartbeat)
+		require.NoError(t, err)
+		require.NotNil(t, response)
+		require.Equal(t, primitive.OpCodeReady, response.Header.OpCode)
+		require.IsType(t, &message.Ready{}, response.Body.Message)
+	}
 }
 
 func testHeartbeat(t *testing.T, clientConn *client.CqlClientConnection) {

--- a/client/handlers_test.go
+++ b/client/handlers_test.go
@@ -109,7 +109,7 @@ func TestNewDriverConnectionInitializationHandler(t *testing.T) {
 }
 
 func TestRawHandler(t *testing.T) {
-	var rawHandler client.RequestRawHandler
+	var rawHandler client.RawRequestHandler
 	rawHandler = func(request *frame.Frame, conn *client.CqlServerConnection, ctx client.RequestHandlerContext) (rawResponse []byte) {
 		bytesBuf := bytes.Buffer{}
 		err := frame.NewCodec().EncodeFrame(frame.NewFrame(primitive.ProtocolVersion4, 1, &message.Ready{}), &bytesBuf)
@@ -120,7 +120,7 @@ func TestRawHandler(t *testing.T) {
 		}
 	}
 	server, clientConn, cancelFn := createServerAndClient(
-		t, []client.RequestHandler{client.HeartbeatHandler}, []client.RequestRawHandler{rawHandler})
+		t, []client.RequestHandler{client.HeartbeatHandler}, []client.RawRequestHandler{rawHandler})
 	defer cancelFn()
 
 	testRawRequestHandler(t, clientConn)
@@ -130,7 +130,7 @@ func TestRawHandler(t *testing.T) {
 
 }
 
-func createServerAndClient(t *testing.T, handlers []client.RequestHandler, rawHandlers []client.RequestRawHandler) (*client.CqlServer, *client.CqlClientConnection, context.CancelFunc) {
+func createServerAndClient(t *testing.T, handlers []client.RequestHandler, rawHandlers []client.RawRequestHandler) (*client.CqlServer, *client.CqlClientConnection, context.CancelFunc) {
 	server := client.NewCqlServer("127.0.0.1:9043", nil)
 	server.RequestHandlers = handlers
 	server.RequestRawHandlers = rawHandlers

--- a/client/prepare_test.go
+++ b/client/prepare_test.go
@@ -70,7 +70,7 @@ func TestNewPreparedStatementHandler(t *testing.T) {
 
 	handler := client.NewPreparedStatementHandler(query, variables, columns, rows)
 
-	server, clientConn, cancelFn := createServerAndClient(t, handler)
+	server, clientConn, cancelFn := createServerAndClient(t, []client.RequestHandler{handler}, nil)
 
 	testUnprepared(t, clientConn, query)
 	testPrepare(t, clientConn, query, variables, columns)

--- a/client/server.go
+++ b/client/server.go
@@ -352,7 +352,7 @@ func newFrameResponse(frameResponse *frame.Frame) *response {
 	}
 }
 
-func NewRawResponse(rawResponse []byte) *response {
+func newRawResponse(rawResponse []byte) *response {
 	return &response{
 		rawResponse: rawResponse,
 	}

--- a/client/server.go
+++ b/client/server.go
@@ -734,7 +734,7 @@ func (c *CqlServerConnection) SendRaw(rawResponse []byte) error {
 	}
 	log.Debug().Msgf("%v: enqueuing outgoing raw response: %v", c, rawResponse)
 	select {
-	case c.outgoing <- NewRawResponse(rawResponse):
+	case c.outgoing <- newRawResponse(rawResponse):
 		log.Debug().Msgf("%v: outgoing frame successfully enqueued: %v", c, rawResponse)
 		return nil
 	default:

--- a/client/server.go
+++ b/client/server.go
@@ -77,6 +77,10 @@ func (ctx requestHandlerContext) GetAttribute(name string) interface{} {
 // if any, may be tried.
 type RequestHandler func(request *frame.Frame, conn *CqlServerConnection, ctx RequestHandlerContext) (response *frame.Frame)
 
+// RequestRawHandler is similar to RequestHandler but returns a raw byte slice, this can be used to return responses that the
+// embedded codecs can't encode
+type RequestRawHandler func(request *frame.Frame, conn *CqlServerConnection, ctx RequestHandlerContext) (rawResponse []byte)
+
 // CqlServer is a minimalistic server stub that can be used to mimic CQL-compatible backends. It is preferable to
 // create CqlServer instances using the constructor function NewCqlServer. Once the server is properly created and
 // configured, use Start to start the server, then call Accept or AcceptAny to accept incoming client connections.
@@ -97,6 +101,8 @@ type CqlServer struct {
 	IdleTimeout time.Duration
 	// RequestHandlers is an optional list of handlers to handle incoming requests.
 	RequestHandlers []RequestHandler
+	// RequestRawHandlers is an optional list of handlers to handle incoming requests and return a response in a byte slice format.
+	RequestRawHandlers []RequestRawHandler
 	// TLSConfig is the TLS configuration to use.
 	TLSConfig *tls.Config
 
@@ -221,6 +227,7 @@ func (server *CqlServer) acceptLoop() {
 					server.MaxInFlight,
 					server.IdleTimeout,
 					server.RequestHandlers,
+					server.RequestRawHandlers,
 					server.connectionsHandler.onConnectionClosed,
 				); err != nil {
 					log.Error().Msgf("%v: failed to accept incoming CQL client connection: %v", server, connection)
@@ -334,6 +341,23 @@ func (server *CqlServer) BindAndInit(
 	}
 }
 
+type Response struct {
+	responseFrame *frame.Frame
+	rawResponse   []byte
+}
+
+func NewFrameResponse(frameResponse *frame.Frame) *Response {
+	return &Response{
+		responseFrame: frameResponse,
+	}
+}
+
+func NewRawResponse(rawResponse []byte) *Response {
+	return &Response{
+		rawResponse: rawResponse,
+	}
+}
+
 // CqlServerConnection encapsulates a TCP server connection to a remote CQL client.
 // CqlServerConnection instances should be created by calling CqlServer.Accept or CqlServer.Bind.
 type CqlServerConnection struct {
@@ -345,9 +369,10 @@ type CqlServerConnection struct {
 	modernLayout       bool
 	idleTimeout        time.Duration
 	handlers           []RequestHandler
+	rawHandlers        []RequestRawHandler
 	handlerCtx         []RequestHandlerContext
 	incoming           chan *frame.Frame
-	outgoing           chan *frame.Frame
+	outgoing           chan *Response
 	waitGroup          *sync.WaitGroup
 	closed             int32
 	onClose            func(*CqlServerConnection)
@@ -363,6 +388,7 @@ func newCqlServerConnection(
 	maxInFlight int,
 	idleTimeout time.Duration,
 	handlers []RequestHandler,
+	rawHandlers []RequestRawHandler,
 	onClose func(*CqlServerConnection),
 ) (*CqlServerConnection, error) {
 	if conn == nil {
@@ -383,9 +409,10 @@ func newCqlServerConnection(
 		credentials:  credentials,
 		idleTimeout:  idleTimeout,
 		handlers:     handlers,
+		rawHandlers:  rawHandlers,
 		handlerCtx:   make([]RequestHandlerContext, len(handlers)),
 		incoming:     make(chan *frame.Frame, maxInFlight),
-		outgoing:     make(chan *frame.Frame, maxInFlight),
+		outgoing:     make(chan *Response, maxInFlight),
 		waitGroup:    &sync.WaitGroup{},
 		onClose:      onClose,
 	}
@@ -461,15 +488,20 @@ func (c *CqlServerConnection) outgoingLoop() {
 				}
 				break
 			} else {
-				if c.compression != primitive.CompressionNone {
-					outgoing.Header.Flags = outgoing.Header.Flags.Add(primitive.HeaderFlagCompressed)
-				}
-				log.Debug().Msgf("%v: sending outgoing frame: %v", c, outgoing)
-				if c.modernLayout {
-					// TODO write coalescer
-					abort = c.writeSegment(outgoing, c.conn)
+				if outgoing.rawResponse != nil {
+					abort = c.writeRawResponse(outgoing.rawResponse, c.conn)
+					log.Debug().Msgf("%v: sending outgoing raw response: %v", c, outgoing.rawResponse)
 				} else {
-					abort = c.writeFrame(outgoing, c.conn)
+					if c.compression != primitive.CompressionNone {
+						outgoing.responseFrame.Header.Flags = outgoing.responseFrame.Header.Flags.Add(primitive.HeaderFlagCompressed)
+					}
+					log.Debug().Msgf("%v: sending outgoing frame: %v", c, outgoing.responseFrame)
+					if c.modernLayout {
+						// TODO write coalescer
+						abort = c.writeSegment(outgoing.responseFrame, c.conn)
+					} else {
+						abort = c.writeFrame(outgoing.responseFrame, c.conn)
+					}
 				}
 			}
 		}
@@ -587,6 +619,15 @@ func (c *CqlServerConnection) writeFrame(outgoing *frame.Frame, dest io.Writer) 
 	return abort
 }
 
+func (c *CqlServerConnection) writeRawResponse(outgoing []byte, dest io.Writer) (abort bool) {
+	if _, err := dest.Write(outgoing); err != nil {
+		abort = c.reportConnectionFailure(err, false)
+	} else {
+		log.Debug().Msgf("%v: outgoing raw response successfully written: %v", c, outgoing)
+	}
+	return abort
+}
+
 func (c *CqlServerConnection) maybeSwitchToModernLayout(outgoing *frame.Frame) {
 	if !c.modernLayout &&
 		outgoing.Header.Version.SupportsModernFramingLayout() &&
@@ -641,19 +682,32 @@ func (c *CqlServerConnection) invokeRequestHandlers(request *frame.Frame) {
 	c.waitGroup.Add(1)
 	go func() {
 		log.Debug().Msgf("%v: invoking request handlers for incoming request: %v", c, request)
-		var response *frame.Frame
 		var err error
-		for i, handler := range c.handlers {
-			if response = handler(request, c, c.handlerCtx[i]); response != nil {
-				log.Debug().Msgf("%v: request handler %v produced response: %v", c, i, response)
-				if err = c.Send(response); err != nil {
-					log.Error().Err(err).Msgf("%v: send failed for frame: %v", c, response)
+		var rawResponse []byte
+		for i, rawHandler := range c.rawHandlers {
+			if rawResponse = rawHandler(request, c, c.handlerCtx[i]); rawResponse != nil {
+				log.Debug().Msgf("%v: request handler %v produced response: %v", c, i, rawResponse)
+				if err = c.SendRaw(rawResponse); err != nil {
+					log.Error().Err(err).Msgf("%v: send failed for frame: %v", c, rawResponse)
 				}
 				break
 			}
 		}
-		if response == nil {
+		if rawResponse == nil {
 			log.Debug().Msgf("%v: no request handler could handle the request: %v", c, request)
+			var response *frame.Frame
+			for i, handler := range c.handlers {
+				if response = handler(request, c, c.handlerCtx[i]); response != nil {
+					log.Debug().Msgf("%v: request handler %v produced response: %v", c, i, response)
+					if err = c.Send(response); err != nil {
+						log.Error().Err(err).Msgf("%v: send failed for frame: %v", c, response)
+					}
+					break
+				}
+			}
+			if response == nil {
+				log.Debug().Msgf("%v: no request handler could handle the request: %v", c, request)
+			}
 		}
 		c.waitGroup.Done()
 	}()
@@ -666,11 +720,26 @@ func (c *CqlServerConnection) Send(f *frame.Frame) error {
 	}
 	log.Debug().Msgf("%v: enqueuing outgoing frame: %v", c, f)
 	select {
-	case c.outgoing <- f:
+	case c.outgoing <- NewFrameResponse(f):
 		log.Debug().Msgf("%v: outgoing frame successfully enqueued: %v", c, f)
 		return nil
 	default:
 		return fmt.Errorf("%v: failed to enqueue outgoing frame: %v", c, f)
+	}
+}
+
+// SendRaw sends the given response frame (already encoded).
+func (c *CqlServerConnection) SendRaw(rawResponse []byte) error {
+	if c.IsClosed() {
+		return fmt.Errorf("%v: connection closed", c)
+	}
+	log.Debug().Msgf("%v: enqueuing outgoing raw response: %v", c, rawResponse)
+	select {
+	case c.outgoing <- NewRawResponse(rawResponse):
+		log.Debug().Msgf("%v: outgoing frame successfully enqueued: %v", c, rawResponse)
+		return nil
+	default:
+		return fmt.Errorf("%v: failed to send outgoing raw response: %v", c, rawResponse)
 	}
 }
 

--- a/client/system_test.go
+++ b/client/system_test.go
@@ -27,7 +27,7 @@ import (
 func TestNewSystemTablesHandler_FullSystemLocal(t *testing.T) {
 
 	handler := client.NewSystemTablesHandler("cluster_test", "datacenter_test")
-	server, clientConn, cancelFunc := createServerAndClient(t, handler)
+	server, clientConn, cancelFunc := createServerAndClient(t, []client.RequestHandler{handler}, nil)
 
 	testFullSystemLocal(t, clientConn)
 
@@ -39,7 +39,7 @@ func TestNewSystemTablesHandler_FullSystemLocal(t *testing.T) {
 func TestNewSystemTablesHandler_SchemaVersion(t *testing.T) {
 
 	handler := client.NewSystemTablesHandler("cluster_test", "datacenter_test")
-	server, clientConn, cancelFunc := createServerAndClient(t, handler)
+	server, clientConn, cancelFunc := createServerAndClient(t, []client.RequestHandler{handler}, nil)
 
 	testSchemaVersion(t, clientConn)
 
@@ -50,7 +50,7 @@ func TestNewSystemTablesHandler_SchemaVersion(t *testing.T) {
 func TestNewSystemTablesHandler_ClusterName(t *testing.T) {
 
 	handler := client.NewSystemTablesHandler("cluster_test", "datacenter_test")
-	server, clientConn, cancelFunc := createServerAndClient(t, handler)
+	server, clientConn, cancelFunc := createServerAndClient(t, []client.RequestHandler{handler}, nil)
 
 	testClusterName(t, clientConn)
 
@@ -61,7 +61,7 @@ func TestNewSystemTablesHandler_ClusterName(t *testing.T) {
 func TestNewSystemTablesHandler_EmptySystemPeers(t *testing.T) {
 
 	handler := client.NewSystemTablesHandler("cluster_test", "datacenter_test")
-	server, clientConn, cancelFunc := createServerAndClient(t, handler)
+	server, clientConn, cancelFunc := createServerAndClient(t, []client.RequestHandler{handler}, nil)
 
 	testSystemPeers(t, clientConn)
 

--- a/client/system_test.go
+++ b/client/system_test.go
@@ -61,7 +61,7 @@ func TestNewSystemTablesHandler_ClusterName(t *testing.T) {
 func TestNewSystemTablesHandler_EmptySystemPeers(t *testing.T) {
 
 	handler := client.NewSystemTablesHandler("cluster_test", "datacenter_test")
-	server, clientConn, cancelFunc := createServerAndClient(t, []client.RequestHandler{handler}, nil)
+	server, clientConn, cancelFunc := createServerAndClient(t, []client.RequestHandler{handler}, nil )
 
 	testSystemPeers(t, clientConn)
 


### PR DESCRIPTION
In order to test some edge cases around invalid or unsupported protocol versions, it is necessary to add a request handler type that returns already encoded responses to bypass the embedded encode process that the `CqlServer` does.